### PR TITLE
Set the annotation name to the same as the event name if the attributes are empty

### DIFF
--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -28,7 +28,6 @@ import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.OtelAttributes;
 import io.opentelemetry.semconv.ServiceAttributes;
 import zipkin2.Endpoint;
-import zipkin2.collector.CollectorMetrics;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -54,7 +53,7 @@ final class SpanTranslator {
       for (ScopeSpans scopeSpans : resourceSpans.getScopeSpansList()) {
         InstrumentationScope scope = scopeSpans.getScope();
         for (io.opentelemetry.proto.trace.v1.Span span : scopeSpans.getSpansList()) {
-            spans.add(generateSpan(span, scope, resourceSpans.getResource()));
+          spans.add(generateSpan(span, scope, resourceSpans.getResource()));
         }
       }
     }
@@ -118,8 +117,15 @@ final class SpanTranslator {
     for (Event eventData : spanData.getEventsList()) {
       // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#events
       String name = eventData.getName();
-      String value = ProtoUtils.kvListToJson(eventData.getAttributesList());
-      String annotation = "\"" + name + "\":" + value;
+      List<KeyValue> attributesList = eventData.getAttributesList();
+      String annotation;
+      if (attributesList.isEmpty()) {
+        annotation = name;
+      }
+      else {
+        String value = ProtoUtils.kvListToJson(attributesList);
+        annotation = "\"" + name + "\":" + value;
+      }
       spanBuilder.addAnnotation(nanoToMills(eventData.getTimeUnixNano()), annotation);
     }
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/mapping-to-non-otlp.md#dropped-events-count

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
@@ -216,9 +216,9 @@ class ITOpenTelemetryHttpCollector {
       // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#events
       assertThat(span.annotations().get(0).value()).isEqualTo("\"event-1\":{\"foo\":\"bar\",\"i\":" + i + "}");
       assertThat(span.annotations().get(0).timestamp()).isEqualTo(toMillis(eventTime1.plusMillis(size)));
-      assertThat(span.annotations().get(1).value()).isEqualTo("\"event-2\":{}");
+      assertThat(span.annotations().get(1).value()).isEqualTo("event-2");
       assertThat(span.annotations().get(1).timestamp()).isEqualTo(toMillis(eventTime2.plusMillis(size)));
-      assertThat(span.annotations().get(2).value()).isEqualTo("\"event-3\":{}");
+      assertThat(span.annotations().get(2).value()).isEqualTo("event-3");
       assertThat(span.annotations().get(2).timestamp()).isEqualTo(toMillis(eventTime3.plusMillis(size)));
     }
     assertThat(metrics.spans()).isEqualTo(size);

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/ZipkinTestUtil.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/ZipkinTestUtil.java
@@ -58,8 +58,8 @@ class ZipkinTestUtil {
         .duration((1505855799000000L + 465726528L / 1000) - (1505855794000000L + 194009601L / 1000))
         .localEndpoint(Endpoint.newBuilder().ip("1.2.3.4").serviceName("tweetiebird").build())
         .putTag(NetworkAttributes.NETWORK_LOCAL_ADDRESS.getKey(), "1.2.3.4")
-        .addAnnotation(1505855799000000L + 433901068L / 1000, "\"RECEIVED\":{}")
-        .addAnnotation(1505855799000000L + 459486280L / 1000, "\"SENT\":{}");
+        .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
+        .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT");
   }
 
   static ExportTraceServiceRequest.Builder requestBuilder(


### PR DESCRIPTION
Following ["OpenTelemetry to Zipkin Transformation"](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#events), I set the annotation name, but I found that if event's attributes is empty, it is meaningless and inconvenient as attached. In this PR, if attributes is empty, the event name is used as the annotation name.

<img width="734" alt="image" src="https://github.com/user-attachments/assets/a4ecbeb1-b5aa-4bce-852e-fdcf5cf5f55b">
