### PR TITLE
Convert the last attribute into tags and count the number of dropped attributes, when attributes with a duplicate key are set

### DIFF
--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -70,7 +70,9 @@ final class SpanTranslator {
   private static zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource) {
     long startTimestamp = nanoToMills(spanData.getStartTimeUnixNano());
     long endTimestamp = nanoToMills(spanData.getEndTimeUnixNano());
-    Map<String, AnyValue> attributesMap = spanData.getAttributesList().stream().collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+    Map<String, AnyValue> attributesMap = spanData.getAttributesList()
+            .stream()
+            .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue, (a, b) -> b /* The latter wins */));
     zipkin2.Span.Builder spanBuilder = zipkin2.Span.newBuilder();
     byte[] traceIdBytes = spanData.getTraceId().toByteArray();
     long high = bytesToLong(traceIdBytes, 0);

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
@@ -429,4 +429,24 @@ class SpanTranslatorTest {
     assertThat(SpanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
+
+
+  @Test
+  void translate_WithDuplicateKeys() {
+    ExportTraceServiceRequest data = requestBuilderWithSpanCustomizer(span -> span
+            .setKind(SpanKind.SPAN_KIND_SERVER)
+            .addAttributes(stringAttribute("foo", "bar1"))
+            .addAttributes(stringAttribute("foo", "bar2"))
+            .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_UNSET).build()))
+            .build();
+
+    Span expectedSpan =
+            zipkinSpanBuilder(Span.Kind.SERVER)
+                    .putTag("foo", "bar2")
+                    .putTag(SpanTranslator.OTEL_DROPPED_ATTRIBUTES_COUNT, "1")
+                    .build();
+
+    assertThat(SpanTranslator.translate(data))
+            .containsExactly(expectedSpan);
+  }
 }


### PR DESCRIPTION
OTEL's spec technically allows attributes to contain multiple same keys (I actually encountered this use case). If converted as is, an `IllegalStateException` occurs.
In this PR, if multiple same keys are added, the attribute will be used. This is the same behavior as when creating a Brave span. And dropped attributes are counted.