### PR TITLE
Support adding static resource attributes on the encoder side

### DIFF
--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
@@ -4,6 +4,9 @@
  */
 package zipkin2.reporter.otel.brave;
 
+import java.util.Collections;
+import java.util.Map;
+
 import brave.Tag;
 import brave.handler.MutableSpan;
 import io.opentelemetry.proto.trace.v1.TracesData;
@@ -13,9 +16,13 @@ import zipkin2.reporter.Encoding;
 public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
   final SpanTranslator spanTranslator;
 
-  public OtlpProtoV1Encoder(Tag<Throwable> errorTag) {
+  public OtlpProtoV1Encoder(Tag<Throwable> errorTag, Map<String, String> resourceAttributes) {
     if (errorTag == null) throw new NullPointerException("errorTag == null");
-    this.spanTranslator = new SpanTranslator(errorTag);
+    this.spanTranslator = new SpanTranslator(errorTag, resourceAttributes);
+  }
+
+  public OtlpProtoV1Encoder(Tag<Throwable> errorTag) {
+    this(errorTag, Collections.emptyMap());
   }
 
   @Override
@@ -23,13 +30,15 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
     return Encoding.PROTO3;
   }
 
-  @Override public int sizeInBytes(MutableSpan span) {
+  @Override
+  public int sizeInBytes(MutableSpan span) {
     // TODO: Create a proto size function to avoid allocations here
     TracesData convert = translate(span);
     return encoding().listSizeInBytes(convert.getSerializedSize());
   }
 
-  @Override public byte[] encode(MutableSpan span) {
+  @Override
+  public byte[] encode(MutableSpan span) {
     return translate(span).toByteArray();
   }
 

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
@@ -32,14 +32,16 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
     public Builder errorTag(Tag<Throwable> errorTag) {
       if (errorTag == null) {
         throw new NullPointerException("errorTag == null");
-      } this.errorTag = errorTag; return this;
+      }
+      this.errorTag = errorTag; return this;
     }
 
     /** static resource attributes added to a {@link io.opentelemetry.proto.resource.v1.Resource}. Defaults to empty map. */
     public Builder resourceAttributes(Map<String, String> resourceAttributes) {
       if (resourceAttributes == null) {
         throw new NullPointerException("resourceAttributes == null");
-      } this.resourceAttributes = resourceAttributes; return this;
+      }
+      this.resourceAttributes = resourceAttributes; return this;
     }
 
     public OtlpProtoV1Encoder build() {

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/ITOtlpProtoV1EncoderTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/ITOtlpProtoV1EncoderTest.java
@@ -112,9 +112,9 @@ public class ITOtlpProtoV1EncoderTest {
   static Stream<Arguments> encoderAndEndpoint() {
     return Stream.of(
         /* existing sender + new encoder -> otlp with otel collector */
-        Arguments.of(Encoding.PROTO3, new OtlpProtoV1Encoder(Tags.ERROR), String.format("http://localhost:%d/v1/traces", collector.getMappedPort(COLLECTOR_OTLP_HTTP_PORT))),
+        Arguments.of(Encoding.PROTO3, OtlpProtoV1Encoder.create(), String.format("http://localhost:%d/v1/traces", collector.getMappedPort(COLLECTOR_OTLP_HTTP_PORT))),
         /* existing sender + new encoder -> otlp without otel collector */
-        Arguments.of(Encoding.PROTO3, new OtlpProtoV1Encoder(Tags.ERROR), String.format("http://localhost:%d/v1/traces", otlpHttpServer.httpPort())),
+        Arguments.of(Encoding.PROTO3, OtlpProtoV1Encoder.create(), String.format("http://localhost:%d/v1/traces", otlpHttpServer.httpPort())),
         /* existing sender + zipkin encoder -> zipkin endpoint on collector */
         Arguments.of(Encoding.JSON, MutableSpanBytesEncoder.create(Encoding.JSON, Tags.ERROR), String.format("http://localhost:%d/api/v2/spans", collector.getMappedPort(COLLECTOR_ZIPKIN_PORT))));
   }

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
@@ -12,7 +12,6 @@ import javax.annotation.Nullable;
 
 import brave.Span;
 import brave.Span.Kind;
-import brave.Tags;
 import brave.handler.MutableSpan;
 import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.common.v1.InstrumentationScope;
@@ -46,7 +45,7 @@ class OtelToZipkinSpanTransformerTest {
 
   @BeforeEach
   void setup() {
-    encoder = new OtlpProtoV1Encoder(Tags.ERROR);
+    encoder = OtlpProtoV1Encoder.create();
   }
 
   @Test
@@ -88,7 +87,7 @@ class OtelToZipkinSpanTransformerTest {
     resourceAttributes.put("os.name", "Linux");
     resourceAttributes.put("os.arch", "amd64");
     resourceAttributes.put("hostname", "localhost");
-    OtlpProtoV1Encoder encoder = new OtlpProtoV1Encoder(Tags.ERROR, resourceAttributes);
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder().resourceAttributes(resourceAttributes).build();
     assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
@@ -129,7 +128,7 @@ class OtelToZipkinSpanTransformerTest {
     resourceAttributes.put("os.name", "Linux");
     resourceAttributes.put("os.arch", "amd64");
     resourceAttributes.put("hostname", "localhost");
-    OtlpProtoV1Encoder encoder = new OtlpProtoV1Encoder(Tags.ERROR, resourceAttributes);
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder().resourceAttributes(resourceAttributes).build();
     assertThat(encoder.translate(data))
             .isEqualTo(
                     TracesData.newBuilder().addResourceSpans(ResourceSpans

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
@@ -4,6 +4,8 @@
  */
 package zipkin2.reporter.otel.brave;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
@@ -26,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.proto.trace.v1.Span.newBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.reporter.otel.brave.SpanTranslator.intAttribute;
@@ -41,18 +42,18 @@ class OtelToZipkinSpanTransformerTest {
 
   static final String PARENT_SPAN_ID = "8b03ab423da481c5";
 
-  private OtlpProtoV1Encoder transformer;
+  private OtlpProtoV1Encoder encoder;
 
   @BeforeEach
   void setup() {
-    transformer = new OtlpProtoV1Encoder(Tags.ERROR);
+    encoder = new OtlpProtoV1Encoder(Tags.ERROR);
   }
 
   @Test
   void generateSpan_remoteParent() {
     MutableSpan data = span(Kind.SERVER);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -80,12 +81,92 @@ class OtelToZipkinSpanTransformerTest {
   }
 
   @Test
+  void generateSpan_resourceAttributes() {
+    MutableSpan data = span(Kind.SERVER);
+    Map<String, String> resourceAttributes = new LinkedHashMap<>();
+    resourceAttributes.put("java.version", "21.0.4");
+    resourceAttributes.put("os.name", "Linux");
+    resourceAttributes.put("os.arch", "amd64");
+    resourceAttributes.put("hostname", "localhost");
+    OtlpProtoV1Encoder encoder = new OtlpProtoV1Encoder(Tags.ERROR, resourceAttributes);
+    assertThat(encoder.translate(data))
+        .isEqualTo(
+            TracesData.newBuilder().addResourceSpans(ResourceSpans
+                    .newBuilder()
+                    .setResource(io.opentelemetry.proto.resource.v1.Resource.newBuilder()
+                        .addAttributes(stringAttribute("service.name", "tweetiebird"))
+                        .addAttributes(stringAttribute("java.version", "21.0.4"))
+                        .addAttributes(stringAttribute("os.name", "Linux"))
+                        .addAttributes(stringAttribute("os.arch", "amd64"))
+                        .addAttributes(stringAttribute("hostname", "localhost")))
+                    .addScopeSpans(ScopeSpans.newBuilder()
+                        .setScope(InstrumentationScope.newBuilder()
+                            .setName(BraveScope.NAME).setVersion(BraveScope.VERSION).build())
+                        .addSpans(newBuilder()
+                            .setSpanId(ByteString.fromHex(data.id()))
+                            .setTraceId(ByteString.fromHex(data.traceId()))
+                            .setParentSpanId(ByteString.fromHex(data.parentId()))
+                            .setName(data.name())
+                            .setStartTimeUnixNano(1505855794194009000L)
+                            .setEndTimeUnixNano(1505855799465726000L)
+                            .setKind(SpanKind.SPAN_KIND_SERVER)
+                            .setStatus(
+                                Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
+                            .addEvents(Event.newBuilder().setName("\"RECEIVED\":{}").setTimeUnixNano(1505855799433901000L).build())
+                            .addEvents(Event.newBuilder().setName("\"SENT\":{}").setTimeUnixNano(1505855799459486000L).build())
+                            .build())
+                        .build())
+                    .build())
+                .build());
+  }
+
+  @Test
+  void generateSpan_resourceAttributes_with_serviceName() {
+    MutableSpan data = span(Kind.SERVER);
+    Map<String, String> resourceAttributes = new LinkedHashMap<>();
+    resourceAttributes.put("service.name", "tweetie-bird");
+    resourceAttributes.put("java.version", "21.0.4");
+    resourceAttributes.put("os.name", "Linux");
+    resourceAttributes.put("os.arch", "amd64");
+    resourceAttributes.put("hostname", "localhost");
+    OtlpProtoV1Encoder encoder = new OtlpProtoV1Encoder(Tags.ERROR, resourceAttributes);
+    assertThat(encoder.translate(data))
+            .isEqualTo(
+                    TracesData.newBuilder().addResourceSpans(ResourceSpans
+                                    .newBuilder()
+                                    .setResource(io.opentelemetry.proto.resource.v1.Resource.newBuilder()
+                                            .addAttributes(stringAttribute("service.name", "tweetie-bird"))
+                                            .addAttributes(stringAttribute("java.version", "21.0.4"))
+                                            .addAttributes(stringAttribute("os.name", "Linux"))
+                                            .addAttributes(stringAttribute("os.arch", "amd64"))
+                                            .addAttributes(stringAttribute("hostname", "localhost")))
+                                    .addScopeSpans(ScopeSpans.newBuilder()
+                                            .setScope(InstrumentationScope.newBuilder()
+                                                    .setName(BraveScope.NAME).setVersion(BraveScope.VERSION).build())
+                                            .addSpans(newBuilder()
+                                                    .setSpanId(ByteString.fromHex(data.id()))
+                                                    .setTraceId(ByteString.fromHex(data.traceId()))
+                                                    .setParentSpanId(ByteString.fromHex(data.parentId()))
+                                                    .setName(data.name())
+                                                    .setStartTimeUnixNano(1505855794194009000L)
+                                                    .setEndTimeUnixNano(1505855799465726000L)
+                                                    .setKind(SpanKind.SPAN_KIND_SERVER)
+                                                    .setStatus(
+                                                            Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
+                                                    .addEvents(Event.newBuilder().setName("\"RECEIVED\":{}").setTimeUnixNano(1505855799433901000L).build())
+                                                    .addEvents(Event.newBuilder().setName("\"SENT\":{}").setTimeUnixNano(1505855799459486000L).build())
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build());
+  }
+  @Test
   void generateSpan_subMicroDurations() {
     MutableSpan data = span(Kind.SERVER);
     data.startTimestamp(TimeUnit.NANOSECONDS.toMicros(1505855794_194009601L));
     data.finishTimestamp(TimeUnit.NANOSECONDS.toMicros(1505855794_194009999L));
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -117,7 +198,7 @@ class OtelToZipkinSpanTransformerTest {
   void generateSpan_ServerKind() {
     MutableSpan data = span(Kind.SERVER);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -148,7 +229,7 @@ class OtelToZipkinSpanTransformerTest {
   void generateSpan_ClientKind() {
     MutableSpan data = span(Kind.CLIENT);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -179,7 +260,7 @@ class OtelToZipkinSpanTransformerTest {
   void generateSpan_DefaultKind() {
     MutableSpan data = span(null);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -210,7 +291,7 @@ class OtelToZipkinSpanTransformerTest {
   void generateSpan_ConsumeKind() {
     MutableSpan data = span(Kind.CONSUMER);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -241,7 +322,7 @@ class OtelToZipkinSpanTransformerTest {
   void generateSpan_ProducerKind() {
     MutableSpan data = span(Kind.PRODUCER);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -273,7 +354,7 @@ class OtelToZipkinSpanTransformerTest {
     MutableSpan data = span(Kind.PRODUCER);
     data.localServiceName("super-zipkin-service");
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -305,7 +386,7 @@ class OtelToZipkinSpanTransformerTest {
     MutableSpan data = span(Kind.PRODUCER);
     data.localServiceName(null);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -343,7 +424,7 @@ class OtelToZipkinSpanTransformerTest {
     data.remotePort(42);
     data.kind(spanKind);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -380,7 +461,7 @@ class OtelToZipkinSpanTransformerTest {
     data.remotePort(42);
     data.kind(spanKind);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -416,7 +497,7 @@ class OtelToZipkinSpanTransformerTest {
     data.remotePort(42);
     data.kind(spanKind);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -451,7 +532,7 @@ class OtelToZipkinSpanTransformerTest {
     data.remoteIp("8.8.8.8");
     data.kind(spanKind);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -485,7 +566,7 @@ class OtelToZipkinSpanTransformerTest {
     data.remoteServiceName("remote-test-service");
     data.kind(spanKind);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -522,7 +603,7 @@ class OtelToZipkinSpanTransformerTest {
     data.tag("doubleArray", "32.33,-98.3");
     data.tag("longArray", "33,999");
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -558,7 +639,7 @@ class OtelToZipkinSpanTransformerTest {
     MutableSpan data = new MutableSpan();
     data.kind(Kind.CLIENT);
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()
@@ -588,7 +669,7 @@ class OtelToZipkinSpanTransformerTest {
     data.error(new RuntimeException("A user provided error"));
     data.tag("http.response.status.code", "404");
 
-    assertThat(transformer.translate(data))
+    assertThat(encoder.translate(data))
         .isEqualTo(
             TracesData.newBuilder().addResourceSpans(ResourceSpans
                     .newBuilder()

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/SpanTranslatorTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/SpanTranslatorTest.java
@@ -6,6 +6,7 @@ package zipkin2.reporter.otel.brave;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import brave.Tags;
@@ -28,7 +29,7 @@ import static zipkin2.reporter.otel.brave.TestObjects.clientSpan;
 
 class SpanTranslatorTest {
 
-  SpanTranslator spanTranslator = new SpanTranslator(Tags.ERROR);
+  SpanTranslator spanTranslator = new SpanTranslator(Tags.ERROR, Collections.emptyMap());
 
   /**
    * This test is intentionally sensitive, so changing other parts makes obvious impact here


### PR DESCRIPTION
This pull request adds a way to add static resource attributes on the encoder side.
Related to #14, resource attributes are typically static and do not depend on a span.

For example, Spring Boot provides `management.opentelemetry.resource-attributes.*` properties to add resource attributes for Otel SDK. This pr will provide the feature parity of this capability for Brave.
https://github.com/spring-projects/spring-boot/blob/aba22547ee56606c815ecb1ef57cee82e9005ed9/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/opentelemetry/OpenTelemetryAutoConfiguration.java#L74-L91


