### PR TITLE
Add a way to map otel resource attributes into tags on the collector side

### DIFF
--- a/collector-http/src/main/java/zipkin2/collector/otel/http/DefaultOtelResourceMapper.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/DefaultOtelResourceMapper.java
@@ -12,16 +12,36 @@ import zipkin2.Span;
  * Default implementation of {@link OtelResourceMapper} that simply maps resource attributes except for {@link ServiceAttributes#SERVICE_NAME} to tags with optional prefix.
  */
 public class DefaultOtelResourceMapper implements OtelResourceMapper {
-  private final String resourceAttributePrefix;
 
-  private static final String DEFAULT_PREFIX = "";
-
-  public DefaultOtelResourceMapper(String resourceAttributePrefix) {
-    this.resourceAttributePrefix = resourceAttributePrefix;
+  public static DefaultOtelResourceMapper create() {
+    return newBuilder().build();
   }
 
-  public DefaultOtelResourceMapper() {
-    this(DEFAULT_PREFIX);
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private String resourceAttributePrefix = "";
+
+    /** The prefix for tags mapped from resource attributes. Defaults to the empty string. */
+    public Builder resourceAttributePrefix(String resourceAttributePrefix) {
+      if (resourceAttributePrefix == null) {
+        throw new NullPointerException("resourceAttributePrefix == null");
+      }
+      this.resourceAttributePrefix = resourceAttributePrefix;
+      return this;
+    }
+
+    public DefaultOtelResourceMapper build() {
+      return new DefaultOtelResourceMapper(this);
+    }
+  }
+
+  private final String resourceAttributePrefix;
+
+  private DefaultOtelResourceMapper(Builder builder) {
+    this.resourceAttributePrefix = builder.resourceAttributePrefix;
   }
 
   public String getResourceAttributePrefix() {

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/DefaultOtelResourceMapper.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/DefaultOtelResourceMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.collector.otel.http;
+
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.semconv.ServiceAttributes;
+import zipkin2.Span;
+
+/**
+ * Default implementation of {@link OtelResourceMapper} that simply maps resource attributes except for {@link ServiceAttributes#SERVICE_NAME} to tags with optional prefix.
+ */
+public class DefaultOtelResourceMapper implements OtelResourceMapper {
+  private final String resourceAttributePrefix;
+
+  private static final String DEFAULT_PREFIX = "";
+
+  public DefaultOtelResourceMapper(String resourceAttributePrefix) {
+    this.resourceAttributePrefix = resourceAttributePrefix;
+  }
+
+  public DefaultOtelResourceMapper() {
+    this(DEFAULT_PREFIX);
+  }
+
+  public String getResourceAttributePrefix() {
+    return resourceAttributePrefix;
+  }
+
+  @Override
+  public void accept(Resource resource, Span.Builder builder) {
+    resource.getAttributesList().stream()
+        .filter(kv -> !kv.getKey().equals(ServiceAttributes.SERVICE_NAME.getKey()))
+        .forEach(kv -> builder.putTag(resourceAttributePrefix + kv.getKey(), ProtoUtils.valueToString(kv.getValue())));
+  }
+}

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
@@ -46,6 +46,8 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
 
     CollectorMetrics metrics = CollectorMetrics.NOOP_METRICS;
 
+    OtelResourceMapper otelResourceMapper;
+
     @Override
     public Builder storage(StorageComponent storageComponent) {
       delegate.storage(storageComponent);
@@ -67,6 +69,11 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
       return this;
     }
 
+    public Builder otelResourceMapper(OtelResourceMapper otelResourceMapper) {
+      this.otelResourceMapper = otelResourceMapper;
+      return this;
+    }
+
     @Override
     public OpenTelemetryHttpCollector build() {
       return new OpenTelemetryHttpCollector(this);
@@ -80,9 +87,12 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
 
   final CollectorMetrics metrics;
 
+  final OtelResourceMapper otelResourceMapper;
+
   OpenTelemetryHttpCollector(Builder builder) {
     collector = builder.delegate.build();
     metrics = builder.metrics;
+    otelResourceMapper = builder.otelResourceMapper == null ? new DefaultOtelResourceMapper() : builder.otelResourceMapper;
   }
 
   @Override
@@ -93,6 +103,10 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
   @Override
   public String toString() {
     return "OpenTelemetryHttpCollector{}";
+  }
+
+  public OtelResourceMapper getOtelResourceMapper() {
+    return otelResourceMapper;
   }
 
   /**
@@ -109,8 +123,11 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
 
     final OpenTelemetryHttpCollector collector;
 
+    final SpanTranslator spanTranslator;
+
     HttpService(OpenTelemetryHttpCollector collector) {
       this.collector = collector;
+      this.spanTranslator = new SpanTranslator(collector.otelResourceMapper);
     }
 
     @Override
@@ -133,7 +150,7 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
             ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(UnsafeByteOperations.unsafeWrap(content.byteBuf().nioBuffer()).newCodedInput());
             collector.metrics.incrementMessages();
             try {
-              List<Span> spans = SpanTranslator.translate(request);
+              List<Span> spans = spanTranslator.translate(request);
               collector.collector.accept(spans, result);
             }
             catch (RuntimeException e) {

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
@@ -92,7 +92,7 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
   OpenTelemetryHttpCollector(Builder builder) {
     collector = builder.delegate.build();
     metrics = builder.metrics;
-    otelResourceMapper = builder.otelResourceMapper == null ? new DefaultOtelResourceMapper() : builder.otelResourceMapper;
+    otelResourceMapper = builder.otelResourceMapper == null ? DefaultOtelResourceMapper.create() : builder.otelResourceMapper;
   }
 
   @Override

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/OtelResourceMapper.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/OtelResourceMapper.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.collector.otel.http;
+
+import java.util.function.BiConsumer;
+
+import io.opentelemetry.proto.resource.v1.Resource;
+
+/**
+ * The interface to map OpenTelemetry Resource to Zipkin Span
+ */
+public interface OtelResourceMapper extends BiConsumer<Resource, zipkin2.Span.Builder> {
+}

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -53,7 +53,7 @@ final class SpanTranslator {
   }
 
   SpanTranslator() {
-    this(new DefaultOtelResourceMapper());
+    this(DefaultOtelResourceMapper.create());
   }
 
 

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -46,7 +46,18 @@ final class SpanTranslator {
 
   static final String ERROR_TAG = "error";
 
-  static List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
+  final OtelResourceMapper resourceMapper;
+
+  SpanTranslator(OtelResourceMapper resourceMapper) {
+    this.resourceMapper = resourceMapper;
+  }
+
+  SpanTranslator() {
+    this(new DefaultOtelResourceMapper());
+  }
+
+
+  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
     List<zipkin2.Span> spans = new ArrayList<>();
     List<ResourceSpans> spansList = otelSpans.getResourceSpansList();
     for (ResourceSpans resourceSpans : spansList) {
@@ -67,12 +78,12 @@ final class SpanTranslator {
    * @param scope InstrumentationScope of the span
    * @return a new Zipkin Span
    */
-  private static zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource) {
+  private zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource) {
     long startTimestamp = nanoToMills(spanData.getStartTimeUnixNano());
     long endTimestamp = nanoToMills(spanData.getEndTimeUnixNano());
     Map<String, AnyValue> attributesMap = spanData.getAttributesList()
-            .stream()
-            .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue, (a, b) -> b /* The latter wins */));
+        .stream()
+        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue, (a, b) -> b /* The latter wins */));
     zipkin2.Span.Builder spanBuilder = zipkin2.Span.newBuilder();
     byte[] traceIdBytes = spanData.getTraceId().toByteArray();
     long high = bytesToLong(traceIdBytes, 0);
@@ -93,6 +104,7 @@ final class SpanTranslator {
         spanBuilder.parentId(parentId);
       }
     }
+    resourceMapper.accept(resource, spanBuilder);
     attributesMap.forEach((k, v) -> spanBuilder.putTag(k, ProtoUtils.valueToString(v)));
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/mapping-to-non-otlp.md#dropped-attributes-count
     int droppedAttributes = spanData.getAttributesCount() - attributesMap.size();

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
@@ -81,6 +81,8 @@ class ITOpenTelemetryHttpCollector {
 
   Server server;
 
+  static final String OTEL_SDK_VERSION = "1.41.0";
+
   @BeforeEach
   public void setup() {
     store = InMemoryStorage.newBuilder().build();
@@ -140,7 +142,7 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.parentId()).isNull();
       assertThat(span.name()).isEqualTo("get");
       assertThat(span.kind()).isEqualTo(zipkin2.Span.Kind.SERVER);
-      assertThat(span.tags()).hasSize(9);
+      assertThat(span.tags()).hasSize(12);
       assertThat(span.tags()).containsEntry("string", "foo" + i);
       assertThat(span.tags()).containsEntry("int", "100");
       assertThat(span.tags()).containsEntry("double", "10.5");
@@ -150,6 +152,10 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_LOCAL_PORT.getKey(), "12345");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_NAME.getKey(), "io.zipkin.contrib.otel:zipkin-collector-otel-http");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_VERSION.getKey(), "0.0.1");
+      // resource attributes
+      assertThat(span.tags()).containsEntry("telemetry.sdk.language", "java");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.name", "opentelemetry");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.version", OTEL_SDK_VERSION);
       assertThat(span.duration()).isGreaterThan(100_000 /* 100ms */).isLessThan(110_000 /* 110ms */);
       assertThat(span.localServiceName()).isEqualTo("zipkin-collector-otel-http-test");
       assertThat(span.localEndpoint().ipv4()).isEqualTo("127.0.0.1");
@@ -200,11 +206,15 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.parentId()).isNull();
       assertThat(span.name()).isEqualTo("do-something");
       assertThat(span.kind()).isEqualTo(zipkin2.Span.Kind.SERVER);
-      assertThat(span.tags()).hasSize(4);
+      assertThat(span.tags()).hasSize(7);
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_LOCAL_ADDRESS.getKey(), "127.0.0.1");
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_LOCAL_PORT.getKey(), "12345");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_NAME.getKey(), "io.zipkin.contrib.otel:zipkin-collector-otel-http");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_VERSION.getKey(), "0.0.1");
+      // resource attributes
+      assertThat(span.tags()).containsEntry("telemetry.sdk.language", "java");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.name", "opentelemetry");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.version", OTEL_SDK_VERSION);
       assertThat(span.duration()).isGreaterThan(100_000 /* 100ms */).isLessThan(110_000 /* 110ms */);
       assertThat(span.localServiceName()).isEqualTo("zipkin-collector-otel-http-test");
       assertThat(span.localEndpoint().ipv4()).isEqualTo("127.0.0.1");
@@ -258,13 +268,17 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.parentId()).isNull();
       assertThat(span.name()).isEqualTo("do-something");
       assertThat(span.kind()).isEqualTo(zipkin2.Span.Kind.SERVER);
-      assertThat(span.tags()).hasSize(6);
+      assertThat(span.tags()).hasSize(9);
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_LOCAL_ADDRESS.getKey(), "127.0.0.1");
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_LOCAL_PORT.getKey(), "12345");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_NAME.getKey(), "io.zipkin.contrib.otel:zipkin-collector-otel-http");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_VERSION.getKey(), "0.0.1");
       assertThat(span.tags()).containsEntry(SpanTranslator.ERROR_TAG, "Exception!!");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR");
+      // resource attributes
+      assertThat(span.tags()).containsEntry("telemetry.sdk.language", "java");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.name", "opentelemetry");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.version", OTEL_SDK_VERSION);
       assertThat(span.duration()).isGreaterThan(100_000 /* 100ms */).isLessThan(110_000 /* 110ms */);
       assertThat(span.localServiceName()).isEqualTo("zipkin-collector-otel-http-test");
       assertThat(span.localEndpoint().ipv4()).isEqualTo("127.0.0.1");
@@ -317,7 +331,7 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.parentId()).isNull();
       assertThat(span.name()).isEqualTo("send");
       assertThat(span.kind()).isEqualTo(zipkin2.Span.Kind.CLIENT);
-      assertThat(span.tags()).hasSize(12);
+      assertThat(span.tags()).hasSize(15);
       assertThat(span.tags()).containsEntry("string", "foo" + i);
       assertThat(span.tags()).containsEntry("int", "100");
       assertThat(span.tags()).containsEntry("double", "10.5");
@@ -330,6 +344,10 @@ class ITOpenTelemetryHttpCollector {
       assertThat(span.tags()).containsEntry(NetworkAttributes.NETWORK_PEER_PORT.getKey(), "8080");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_NAME.getKey(), "io.zipkin.contrib.otel:zipkin-collector-otel-http");
       assertThat(span.tags()).containsEntry(OtelAttributes.OTEL_SCOPE_VERSION.getKey(), "0.0.1");
+      // resource attributes
+      assertThat(span.tags()).containsEntry("telemetry.sdk.language", "java");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.name", "opentelemetry");
+      assertThat(span.tags()).containsEntry("telemetry.sdk.version", OTEL_SDK_VERSION);
       assertThat(span.duration()).isGreaterThan(100_000 /* 100ms */).isLessThan(110_000 /* 110ms */);
       assertThat(span.localServiceName()).isEqualTo("zipkin-collector-otel-http-test");
       assertThat(span.localEndpoint().ipv4()).isEqualTo("127.0.0.1");

--- a/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModule.java
+++ b/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModule.java
@@ -5,30 +5,43 @@
 package zipkin.module.otel;
 
 import com.linecorp.armeria.spring.ArmeriaServerConfigurator;
+import zipkin2.collector.CollectorMetrics;
+import zipkin2.collector.CollectorSampler;
+import zipkin2.collector.otel.http.DefaultOtelResourceMapper;
+import zipkin2.collector.otel.http.OpenTelemetryHttpCollector;
+import zipkin2.collector.otel.http.OtelResourceMapper;
+import zipkin2.storage.StorageComponent;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import zipkin2.collector.CollectorMetrics;
-import zipkin2.collector.CollectorSampler;
-import zipkin2.collector.otel.http.OpenTelemetryHttpCollector;
-import zipkin2.storage.StorageComponent;
 
 @Configuration
 @ConditionalOnProperty(name = "zipkin.collector.otel.http.enabled", matchIfMissing = true)
 @EnableConfigurationProperties(ZipkinOpenTelemetryHttpCollectorProperties.class)
 class ZipkinOpenTelemetryHttpCollectorModule {
-  @Bean OpenTelemetryHttpCollector otelHttpCollector(StorageComponent storage,
-      CollectorSampler sampler, CollectorMetrics metrics) {
+  @Bean
+  OpenTelemetryHttpCollector otelHttpCollector(StorageComponent storage,
+      CollectorSampler sampler, CollectorMetrics metrics, OtelResourceMapper otelResourceMapper) {
     return OpenTelemetryHttpCollector.newBuilder()
         .storage(storage)
         .sampler(sampler)
         .metrics(metrics)
+        .otelResourceMapper(otelResourceMapper)
         .build();
   }
 
-  @Bean ArmeriaServerConfigurator otelHttpCollectorConfigurator(
+  @Bean
+  ArmeriaServerConfigurator otelHttpCollectorConfigurator(
       OpenTelemetryHttpCollector collector) {
     return collector::reconfigure;
+  }
+
+  @ConditionalOnMissingBean(OtelResourceMapper.class)
+  @Bean
+  OtelResourceMapper otelResourceMapper(ZipkinOpenTelemetryHttpCollectorProperties properties) {
+    return new DefaultOtelResourceMapper(properties.resourceAttributePrefix());
   }
 }

--- a/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModule.java
+++ b/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModule.java
@@ -42,6 +42,10 @@ class ZipkinOpenTelemetryHttpCollectorModule {
   @ConditionalOnMissingBean(OtelResourceMapper.class)
   @Bean
   OtelResourceMapper otelResourceMapper(ZipkinOpenTelemetryHttpCollectorProperties properties) {
-    return new DefaultOtelResourceMapper(properties.resourceAttributePrefix());
+    DefaultOtelResourceMapper.Builder builder = DefaultOtelResourceMapper.newBuilder();
+    if (properties.getResourceAttributePrefix() != null) {
+      builder.resourceAttributePrefix(properties.getResourceAttributePrefix());
+    }
+    return builder.build();
   }
 }

--- a/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorProperties.java
+++ b/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorProperties.java
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ZipkinOpenTelemetryHttpCollectorProperties {
   private String resourceAttributePrefix;
 
-  public String resourceAttributePrefix() {
+  public String getResourceAttributePrefix() {
     return resourceAttributePrefix;
   }
 

--- a/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorProperties.java
+++ b/module/src/main/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorProperties.java
@@ -8,4 +8,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("zipkin.collector.otel.http")
 public class ZipkinOpenTelemetryHttpCollectorProperties {
+  private String resourceAttributePrefix;
+
+  public String resourceAttributePrefix() {
+    return resourceAttributePrefix;
+  }
+
+  public void setResourceAttributePrefix(String resourceAttributePrefix) {
+    this.resourceAttributePrefix = resourceAttributePrefix;
+  }
 }

--- a/module/src/main/resources/zipkin-server-otel.yml
+++ b/module/src/main/resources/zipkin-server-otel.yml
@@ -8,3 +8,4 @@ zipkin:
       http:
         # Set to false to disable creation of spans via OLTP/HTTP protocol
         enabled: ${COLLECTOR_HTTP_ENABLED:${COLLECTOR_OTEL_HTTP_ENABLED:true}}
+        resource-attribute-prefix: ${COLLECTOR_OTEL_RESOURCE_ATTRIBUTE_PREFIX:}

--- a/module/src/test/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModuleTest.java
+++ b/module/src/test/java/zipkin/module/otel/ZipkinOpenTelemetryHttpCollectorModuleTest.java
@@ -29,9 +29,15 @@ class ZipkinOpenTelemetryHttpCollectorModuleTest {
   void httpCollector_enabledByDefault() {
     contextRunner.withUserConfiguration(ZipkinOpenTelemetryHttpCollectorModule.class)
         .withUserConfiguration(InMemoryConfiguration.class)
-        .run(context -> assertThat(context).hasSingleBean(OpenTelemetryHttpCollector.class)
-            .hasSingleBean(DefaultOtelResourceMapper.class)
-            .hasSingleBean(ArmeriaServerConfigurator.class));
+        .run(context -> {
+          assertThat(context).hasSingleBean(OpenTelemetryHttpCollector.class)
+              .hasSingleBean(DefaultOtelResourceMapper.class)
+              .hasSingleBean(ArmeriaServerConfigurator.class);
+          OpenTelemetryHttpCollector collector = context.getBean(OpenTelemetryHttpCollector.class);
+          OtelResourceMapper otelResourceMapper = collector.getOtelResourceMapper();
+          assertThat(otelResourceMapper).isInstanceOf(DefaultOtelResourceMapper.class);
+          assertThat(((DefaultOtelResourceMapper) otelResourceMapper).getResourceAttributePrefix()).isEqualTo("");
+        });
   }
 
   @Test


### PR DESCRIPTION
This pr adds a way to map otel resource attributes into tags on the collector side.
Related to #14.

By default it simply maps resource attributes except for `service.name` to tags with optional prefix. Providing `OtelResourceMapper` instance can replace the behavior (e.g. do not convert anything, or convert only certain attributes to tags.).