### PR TITLE
Bump opentelemetry-proto to 1.4.0-alpha

### DIFF
--- a/collector-http/pom.xml
+++ b/collector-http/pom.xml
@@ -50,13 +50,6 @@
       <artifactId>opentelemetry-semconv</artifactId>
       <version>${opentelemetry-semconv.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-      <!-- We use provided scope to avoid pinning a protobuf version -->
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>${zipkin.groupId}</groupId>

--- a/encoder-brave/pom.xml
+++ b/encoder-brave/pom.xml
@@ -43,13 +43,6 @@
       <artifactId>opentelemetry-semconv</artifactId>
       <version>${opentelemetry-semconv.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-      <!-- We use provided scope to avoid pinning a protobuf version -->
-      <scope>provided</scope>
-    </dependency>
 
     <!-- Encoder/Data type deps -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <opentelemetry.version>1.43.0</opentelemetry.version>
     <!-- Alpha jar! -->
     <opentelemetry-proto.version>1.4.0-alpha</opentelemetry-proto.version>
-    <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
+    <opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
 
     <assertj.version>3.25.3</assertj.version>
     <awaitility.version>4.2.1</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <opentelemetry.version>1.43.0</opentelemetry.version>
     <!-- Alpha jar! -->
     <opentelemetry-proto.version>1.4.0-alpha</opentelemetry-proto.version>
-    <opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
+    <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
 
     <assertj.version>3.25.3</assertj.version>
     <awaitility.version>4.2.1</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,8 @@
 
     <opentelemetry.version>1.43.0</opentelemetry.version>
     <!-- Alpha jar! -->
-    <opentelemetry-proto.version>1.3.2-alpha</opentelemetry-proto.version>
+    <opentelemetry-proto.version>1.4.0-alpha</opentelemetry-proto.version>
     <opentelemetry-semconv.version>1.28.0-alpha</opentelemetry-semconv.version>
-    <!-- from grpc-protobuf -->
-    <protobuf.version>3.25.5</protobuf.version>
 
     <assertj.version>3.25.3</assertj.version>
     <awaitility.version>4.2.1</awaitility.version>


### PR DESCRIPTION
Fixes https://github.com/advisories/GHSA-735f-pc8j-v9w8.
This PR also removes the explicit definition of protobuf-java.
protobuf-java is actually derived from opentelemetry-proto. This update also transitively updates protobuf-java 3 -> 4.