### PR TITLE
Make Brave InstrumentationScope configurable

### DIFF
--- a/encoder-brave/README.md
+++ b/encoder-brave/README.md
@@ -4,5 +4,18 @@ This encodes brave spans into OTLP proto format.
 
 ```java
 // Use OTLP encoder when sending to an OTLP backend
-spanHandler = AsyncZipkinSpanHandler.newBuilder(sender).build(new OtlpProtoV1Encoder(Tags.ERROR));
+spanHandler = AsyncZipkinSpanHandler.newBuilder(sender).build(OtlpProtoV1Encoder.create());
+```
+
+You can customize `OtlpProtoV1Encoder` as follows:
+
+```java
+OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+    // OpenTelemetry Instrumentation scope
+    .instrumentationScope(new InstrumentationScope("com.example.app", "1.0.0"))
+    // OpenTelemetry Resource Attributes
+    .resourceAttributes(Map.of("key", "value"))
+    // Brave Error Tag
+    .errorTag(Tags.ERROR)
+    .build();
 ```

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/BraveScope.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/BraveScope.java
@@ -17,6 +17,8 @@ final class BraveScope {
 
   static final String VERSION;
 
+  static final InstrumentationScope INSTRUMENTATION_SCOPE;
+
   static {
     try (InputStream stream = BraveScope.class.getClassLoader().getResourceAsStream("scope.properties")) {
       if (stream != null) {
@@ -24,15 +26,18 @@ final class BraveScope {
         props.load(stream);
         NAME = props.getProperty("name");
         VERSION = props.getProperty("version");
-      }
-      else {
+      } else {
         NAME = "unknown";
         VERSION = "unknown";
       }
-    }
-    catch (IOException e) {
+      INSTRUMENTATION_SCOPE = new InstrumentationScope(NAME, VERSION);
+    } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  public static InstrumentationScope instrumentationScope() {
+    return INSTRUMENTATION_SCOPE;
   }
 
 }

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/InstrumentationScope.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/InstrumentationScope.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.otel.brave;
+
+import java.util.Objects;
+
+/**
+ * OpenTelemetry InstrumentationScope
+ */
+public final class InstrumentationScope {
+  private final String name;
+  private final String version;
+
+  public InstrumentationScope(String name, String version) {
+    this.name = name;
+    this.version = version;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String version() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    InstrumentationScope that = (InstrumentationScope) o;
+    return Objects.equals(name, that.name) && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version);
+  }
+}

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/InstrumentationScope.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/InstrumentationScope.java
@@ -7,7 +7,12 @@ package zipkin2.reporter.otel.brave;
 import java.util.Objects;
 
 /**
- * OpenTelemetry InstrumentationScope
+ * Instrumentation Scope indicates the application component that produced spans. This is more
+ * specific than the local service name.
+ * <p>
+ * See https://opentelemetry.io/docs/specs/otel/glossary/#instrumentation-scope
+ *
+ * @see BraveScope#instrumentationScope
  */
 public final class InstrumentationScope {
   private final String name;

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
@@ -28,12 +28,15 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
 
     Map<String, String> resourceAttributes = Collections.emptyMap();
 
+    InstrumentationScope instrumentationScope = BraveScope.instrumentationScope();
+
     /** The throwable parser. Defaults to {@link Tags#ERROR}. */
     public Builder errorTag(Tag<Throwable> errorTag) {
       if (errorTag == null) {
         throw new NullPointerException("errorTag == null");
       }
-      this.errorTag = errorTag; return this;
+      this.errorTag = errorTag;
+      return this;
     }
 
     /** static resource attributes added to a {@link io.opentelemetry.proto.resource.v1.Resource}. Defaults to empty map. */
@@ -41,7 +44,17 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
       if (resourceAttributes == null) {
         throw new NullPointerException("resourceAttributes == null");
       }
-      this.resourceAttributes = resourceAttributes; return this;
+      this.resourceAttributes = resourceAttributes;
+      return this;
+    }
+
+    /** The Instrumentation scope which represents a logical unit within the application code with which the emitted telemetry can be associated */
+    public Builder instrumentationScope(InstrumentationScope instrumentationScope) {
+      if (instrumentationScope == null) {
+        throw new NullPointerException("implementationScope == null");
+      }
+      this.instrumentationScope = instrumentationScope;
+      return this;
     }
 
     public OtlpProtoV1Encoder build() {
@@ -56,7 +69,11 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
   final SpanTranslator spanTranslator;
 
   private OtlpProtoV1Encoder(Builder builder) {
-    this.spanTranslator = new SpanTranslator(builder.errorTag, builder.resourceAttributes);
+    this.spanTranslator = SpanTranslator.newBuilder()
+        .errorTag(builder.errorTag)
+        .resourceAttributes(builder.resourceAttributes)
+        .instrumentationScope(builder.instrumentationScope)
+        .build();
   }
 
   @Override

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtlpProtoV1EncoderTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtlpProtoV1EncoderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.otel.brave;
+
+import brave.Tag;
+import brave.Tags;
+import brave.propagation.TraceContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpProtoV1EncoderTest {
+  @Test
+  void defaultConfiguration() {
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+        .build();
+    SpanTranslator spanTranslator = encoder.spanTranslator;
+    assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
+    assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
+    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+  }
+
+  @Test
+  void customResourceAttributes() {
+    Map<String, String> resourceAttributes = Collections.singletonMap("key", "value");
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+        .resourceAttributes(resourceAttributes)
+        .build();
+    SpanTranslator spanTranslator = encoder.spanTranslator;
+    assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
+    assertThat(spanTranslator.resourceAttributes).isEqualTo(resourceAttributes);
+    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+  }
+
+  @Test
+  void customInstrumentationScope() {
+    InstrumentationScope instrumentationScope = new InstrumentationScope("com.example.app", "1.0.0");
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+        .instrumentationScope(instrumentationScope)
+        .build();
+    SpanTranslator spanTranslator = encoder.spanTranslator;
+    assertThat(spanTranslator.instrumentationScope).isEqualTo(instrumentationScope);
+    assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
+    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+  }
+
+  @Test
+  void customErrorTag() {
+    Tag<Throwable> errorTag = new Tag<Throwable>("test") {
+      @Override
+      protected String parseValue(Throwable input, TraceContext context) {
+        return "test";
+      }
+    };
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+        .errorTag(errorTag)
+        .build();
+    SpanTranslator spanTranslator = encoder.spanTranslator;
+    assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
+    assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
+    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(errorTag);
+  }
+}


### PR DESCRIPTION
This PR makes the [InstrumentationScope](https://opentelemetry.io/docs/concepts/instrumentation-scope/) configurable.

For example, Spring Boot uses `org.springframework.boot` and its version as the instrumentation scope for OTEL SDK.
https://github.com/spring-projects/spring-boot/blob/v3.4.1/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/tracing/OpenTelemetryTracingAutoConfiguration.java#L137
