### PR TITLE
Make the mapping from brave tags to otel attributes configurable

### DIFF
--- a/encoder-brave/README.md
+++ b/encoder-brave/README.md
@@ -15,6 +15,12 @@ OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
     .instrumentationScope(new InstrumentationScope("com.example.app", "1.0.0"))
     // OpenTelemetry Resource Attributes
     .resourceAttributes(Map.of("key", "value"))
+    // Mapping from Brave Tags to OpenTelemetry Attributes
+    .tagToAttributes(TagToAttributes.newBuilder()
+        .withDefaults()
+        .tagToAttribute("method", "http.request.method")
+        .tagToAttribute("status", "http.response.status_code")
+        .build())
     // Brave Error Tag
     .errorTag(Tags.ERROR)
     .build();

--- a/encoder-brave/pom.xml
+++ b/encoder-brave/pom.xml
@@ -61,6 +61,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>${opentelemetry.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.semconv</groupId>
+      <artifactId>opentelemetry-semconv</artifactId>
+      <version>${opentelemetry-semconv.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${armeria.groupId}</groupId>
       <artifactId>armeria-junit5</artifactId>
       <version>${armeria.version}</version>

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/OtlpProtoV1Encoder.java
@@ -4,15 +4,15 @@
  */
 package zipkin2.reporter.otel.brave;
 
-import java.util.Collections;
-import java.util.Map;
-
 import brave.Tag;
 import brave.Tags;
 import brave.handler.MutableSpan;
 import io.opentelemetry.proto.trace.v1.TracesData;
 import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.Encoding;
+
+import java.util.Collections;
+import java.util.Map;
 
 public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
   public static OtlpProtoV1Encoder create() {
@@ -26,11 +26,15 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
   public static final class Builder {
     Tag<Throwable> errorTag = Tags.ERROR;
 
+    TagToAttributes tagToAttributes;
+
     Map<String, String> resourceAttributes = Collections.emptyMap();
 
     InstrumentationScope instrumentationScope = BraveScope.instrumentationScope();
 
-    /** The throwable parser. Defaults to {@link Tags#ERROR}. */
+    /**
+     * The throwable parser. Defaults to {@link Tags#ERROR}.
+     */
     public Builder errorTag(Tag<Throwable> errorTag) {
       if (errorTag == null) {
         throw new NullPointerException("errorTag == null");
@@ -39,7 +43,17 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
       return this;
     }
 
-    /** static resource attributes added to a {@link io.opentelemetry.proto.resource.v1.Resource}. Defaults to empty map. */
+    public Builder tagToAttributes(TagToAttributes tagToAttributes) {
+      if (tagToAttributes == null) {
+        throw new NullPointerException("tagToAttributes == null");
+      }
+      this.tagToAttributes = tagToAttributes;
+      return this;
+    }
+
+    /**
+     * static resource attributes added to a {@link io.opentelemetry.proto.resource.v1.Resource}. Defaults to empty map.
+     */
     public Builder resourceAttributes(Map<String, String> resourceAttributes) {
       if (resourceAttributes == null) {
         throw new NullPointerException("resourceAttributes == null");
@@ -48,7 +62,9 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
       return this;
     }
 
-    /** The Instrumentation scope which represents a logical unit within the application code with which the emitted telemetry can be associated */
+    /**
+     * The Instrumentation scope which represents a logical unit within the application code with which the emitted telemetry can be associated
+     */
     public Builder instrumentationScope(InstrumentationScope instrumentationScope) {
       if (instrumentationScope == null) {
         throw new NullPointerException("implementationScope == null");
@@ -71,6 +87,7 @@ public final class OtlpProtoV1Encoder implements BytesEncoder<MutableSpan> {
   private OtlpProtoV1Encoder(Builder builder) {
     this.spanTranslator = SpanTranslator.newBuilder()
         .errorTag(builder.errorTag)
+        .tagToAttributes(builder.tagToAttributes)
         .resourceAttributes(builder.resourceAttributes)
         .instrumentationScope(builder.instrumentationScope)
         .build();

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SemanticConventionsAttributes.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SemanticConventionsAttributes.java
@@ -30,6 +30,12 @@ final class SemanticConventionsAttributes {
   static final String URL_FULL = "url.full";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java#L71
   static final String URL_PATH = "url.path";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java#L103
+  static final String URL_QUERY = "url.query";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java#L109
+  static final String URL_SCHEME = "url.scheme";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java#L17
+  static final String URL_FRAGMENT = "url.fragment";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv-incubating/src/main/java/io/opentelemetry/semconv/incubating/PeerIncubatingAttributes.java#L21
   static final String PEER_SERVICE = "peer.service";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/TelemetryAttributes.java#L17

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/TagToAttribute.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/TagToAttribute.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.otel.brave;
+
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.trace.v1.Span;
+
+/**
+ * Map a Brave Tag to OTel attributes. <br>
+ * The mapping can be one to many.
+ */
+@FunctionalInterface
+public interface TagToAttribute {
+
+  void mapTag(Span.Builder spanBuilder, String value);
+
+  /**
+   * simple 1:1 mapping from a brave tag key to an otel attribute name with the same value.
+   */
+  static TagToAttribute keyToAttributeName(String attributeName) {
+    return (spanBuilder, value) -> spanBuilder.addAttributes(stringAttribute(attributeName, value));
+  }
+
+  static KeyValue stringAttribute(String key, String value) {
+    return KeyValue.newBuilder()
+        .setKey(key)
+        .setValue(AnyValue.newBuilder().setStringValue(value))
+        .build();
+  }
+
+  static KeyValue intAttribute(String key, int value) {
+    return KeyValue.newBuilder()
+        .setKey(key)
+        .setValue(AnyValue.newBuilder().setIntValue(value))
+        .build();
+  }
+
+  static void maybeAddStringAttribute(Span.Builder spanBuilder, String key, String value) {
+    if (value != null) {
+      spanBuilder.addAttributes(stringAttribute(key, value));
+    }
+  }
+
+  static void maybeAddIntAttribute(Span.Builder spanBuilder, String key, int value) {
+    if (value != 0) {
+      spanBuilder.addAttributes(intAttribute(key, value));
+    }
+  }
+}

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/TagToAttributes.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/TagToAttributes.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.otel.brave;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.http.HttpTags;
+import io.opentelemetry.proto.trace.v1.Span;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static zipkin2.reporter.otel.brave.TagToAttribute.keyToAttributeName;
+import static zipkin2.reporter.otel.brave.TagToAttribute.maybeAddStringAttribute;
+import static zipkin2.reporter.otel.brave.TagToAttribute.stringAttribute;
+
+/**
+ * Tag to Attribute mappings which map brave data policy to otel semantics.
+ *
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/http/http-spans/">https://opentelemetry.io/docs/specs/semconv/http/http-spans/</a>
+ * @see brave.http.HttpTags
+ */
+public final class TagToAttributes implements MutableSpan.TagConsumer<Span.Builder> {
+
+  public static TagToAttributes create() {
+    return newBuilder().withDefaults().build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private final Map<String, TagToAttribute> map = new LinkedHashMap<>();
+
+    /**
+     * Covert brave <code>http.url</code> tag to otel attributes.<br>
+     * If the <code>http.url</code> is full, it will be parsed further into attributes.
+     */
+    private static final TagToAttribute URL_TAG_TO_ATTRIBUTE = (spanBuilder, value) -> {
+      if (value.startsWith("http")) {
+        try {
+          URI uri = URI.create(value);
+          spanBuilder.addAttributes(stringAttribute(SemanticConventionsAttributes.URL_FULL, value));
+          // map URI parts to "stable" attributes as of OpenTelemetry Semantic Conventions 1.29.0
+          maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.URL_SCHEME, uri.getScheme());
+          maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.URL_PATH, uri.getPath());
+          maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.URL_QUERY, uri.getQuery());
+          maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.URL_FRAGMENT, uri.getFragment());
+        } catch (IllegalArgumentException e) {
+          // do not convert
+          spanBuilder.addAttributes(stringAttribute(HttpTags.URL.key(), value));
+        }
+      } else if (value.startsWith("/")) {
+        // There are also libraries (like Spring Framework) that only include the path in `http.url` tag.
+        spanBuilder.addAttributes(stringAttribute(SemanticConventionsAttributes.URL_PATH, value));
+      } else {
+        // do not covert due to the unexpected format
+        spanBuilder.addAttributes(stringAttribute(HttpTags.URL.key(), value));
+      }
+    };
+
+    /**
+     * Default tag to attribute mappings
+     */
+    public Builder withDefaults() {
+      // TODO: brave also defines rpc and messaging data policy
+      return this
+          .tagToAttribute(HttpTags.METHOD, SemanticConventionsAttributes.HTTP_REQUEST_METHOD)
+          .tagToAttribute(HttpTags.PATH, SemanticConventionsAttributes.URL_PATH)
+          .tagToAttribute(HttpTags.ROUTE, SemanticConventionsAttributes.HTTP_ROUTE)
+          .tagToAttribute(HttpTags.URL.key(), URL_TAG_TO_ATTRIBUTE)
+          .tagToAttribute(HttpTags.STATUS_CODE, SemanticConventionsAttributes.HTTP_RESPONSE_STATUS_CODE);
+    }
+
+    /**
+     * Set the mapping by <code>tagToAttribute</code> to the <code>tagKey</code>.
+     */
+    public Builder tagToAttribute(String tagKey, TagToAttribute tagToAttribute) {
+      if (tagKey == null) {
+        throw new IllegalArgumentException("tagKey == null");
+      }
+      if (tagToAttribute == null) {
+        throw new NullPointerException("tagToAttribute == null");
+      }
+      map.put(tagKey, tagToAttribute);
+      return this;
+    }
+
+    /**
+     * Set a simple 1:1 mapping from a brave tag key to an otel attribute name with the same value.
+     */
+    public Builder tagToAttribute(String tagKey, String attributeName) {
+      if (attributeName == null) {
+        throw new IllegalArgumentException("attributeName == null");
+      }
+      return this.tagToAttribute(tagKey, keyToAttributeName(attributeName));
+    }
+
+    /**
+     * Set a simple 1:1 mapping from a brave tag key to an otel attribute name with the same value.
+     */
+    public Builder tagToAttribute(Tag<?> tag, String attributeName) {
+      if (attributeName == null) {
+        throw new IllegalArgumentException("attributeName == null");
+      }
+      return this.tagToAttribute(tag.key(), keyToAttributeName(attributeName));
+    }
+
+    /**
+     * Set a map of brave tag key to otel attribute name
+     */
+    public Builder tagToAttributes(Map<String, String> tagToAttributes) {
+      if (tagToAttributes == null) {
+        throw new NullPointerException("tagToAttributes == null");
+      }
+      tagToAttributes.forEach(this::tagToAttribute);
+      return this;
+    }
+
+    public TagToAttributes build() {
+      return new TagToAttributes(this);
+    }
+  }
+
+  private final Map<String, TagToAttribute> tagToAttributeMap;
+
+  public TagToAttributes(Builder builder) {
+    this.tagToAttributeMap = Collections.unmodifiableMap(builder.map);
+  }
+
+  @Override
+  public void accept(Span.Builder target, String tagKey, String tagValue) {
+    TagToAttribute tagToAttribute = this.tagToAttributeMap.get(tagKey);
+    if (tagToAttribute != null) {
+      tagToAttribute.mapTag(target, tagValue);
+    } else {
+      target.addAttributes(stringAttribute(tagKey, tagValue));
+    }
+  }
+}

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
@@ -4,12 +4,6 @@
  */
 package zipkin2.reporter.otel.brave;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nullable;
-
 import brave.Span;
 import brave.Span.Kind;
 import brave.handler.MutableSpan;
@@ -27,10 +21,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import static io.opentelemetry.proto.trace.v1.Span.newBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static zipkin2.reporter.otel.brave.SpanTranslator.intAttribute;
-import static zipkin2.reporter.otel.brave.SpanTranslator.stringAttribute;
+import static zipkin2.reporter.otel.brave.TagToAttribute.intAttribute;
+import static zipkin2.reporter.otel.brave.TagToAttribute.stringAttribute;
 
 // Adapted from https://github.com/open-telemetry/opentelemetry-java/blob/v1.39.0/exporters/zipkin/src/test/java/io/opentelemetry/exporter/zipkin/OtelToZipkinSpanTransformerTest.java
 class OtelToZipkinSpanTransformerTest {

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtlpProtoV1EncoderTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtlpProtoV1EncoderTest.java
@@ -22,7 +22,8 @@ class OtlpProtoV1EncoderTest {
     SpanTranslator spanTranslator = encoder.spanTranslator;
     assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
     assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
-    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.tagToAttributes).isNotNull();
   }
 
   @Test
@@ -34,7 +35,8 @@ class OtlpProtoV1EncoderTest {
     SpanTranslator spanTranslator = encoder.spanTranslator;
     assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
     assertThat(spanTranslator.resourceAttributes).isEqualTo(resourceAttributes);
-    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.tagToAttributes).isNotNull();
   }
 
   @Test
@@ -46,7 +48,8 @@ class OtlpProtoV1EncoderTest {
     SpanTranslator spanTranslator = encoder.spanTranslator;
     assertThat(spanTranslator.instrumentationScope).isEqualTo(instrumentationScope);
     assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
-    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.errorTag).isEqualTo(Tags.ERROR);
+    assertThat(spanTranslator.tagToAttributes).isNotNull();
   }
 
   @Test
@@ -63,6 +66,19 @@ class OtlpProtoV1EncoderTest {
     SpanTranslator spanTranslator = encoder.spanTranslator;
     assertThat(spanTranslator.instrumentationScope).isEqualTo(BraveScope.instrumentationScope());
     assertThat(spanTranslator.resourceAttributes).isEqualTo(Collections.emptyMap());
-    assertThat(spanTranslator.tagMapper.errorTag).isEqualTo(errorTag);
+    assertThat(spanTranslator.errorTag).isEqualTo(errorTag);
+    assertThat(spanTranslator.tagToAttributes).isNotNull();
+  }
+
+  @Test
+  void customTagToAttributes() {
+    TagToAttributes tagToAttributes = TagToAttributes.newBuilder()
+        .tagToAttribute("abc", "xyz")
+        .build();
+    OtlpProtoV1Encoder encoder = OtlpProtoV1Encoder.newBuilder()
+        .tagToAttributes(tagToAttributes)
+        .build();
+    SpanTranslator spanTranslator = encoder.spanTranslator;
+    assertThat(spanTranslator.tagToAttributes).isEqualTo(tagToAttributes);
   }
 }

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/SpanTranslatorTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/SpanTranslatorTest.java
@@ -4,11 +4,6 @@
  */
 package zipkin2.reporter.otel.brave;
 
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.TimeUnit;
-
 import brave.Tags;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
@@ -21,12 +16,22 @@ import io.opentelemetry.proto.trace.v1.Span.SpanKind;
 import io.opentelemetry.proto.trace.v1.Status;
 import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import io.opentelemetry.proto.trace.v1.TracesData;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
 import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.reporter.otel.brave.SpanTranslator.DEFAULT_SPAN_NAME;
-import static zipkin2.reporter.otel.brave.SpanTranslator.intAttribute;
-import static zipkin2.reporter.otel.brave.SpanTranslator.stringAttribute;
+import static zipkin2.reporter.otel.brave.TagToAttribute.intAttribute;
+import static zipkin2.reporter.otel.brave.TagToAttribute.stringAttribute;
 import static zipkin2.reporter.otel.brave.TestObjects.clientSpan;
 
 class SpanTranslatorTest {
@@ -60,12 +65,14 @@ class SpanTranslatorTest {
                     TimeUnit.MILLISECONDS.toNanos(
                         Instant.ofEpochSecond(1472470996, 406_000_000).toEpochMilli()))
                 .addAllAttributes(
-                    Arrays.asList(stringAttribute("network.local.address", "127.0.0.1"),
-                        stringAttribute("network.peer.address", "192.168.99.101"),
-                        intAttribute("network.peer.port", 9000),
+                    Arrays.asList(stringAttribute(NetworkAttributes.NETWORK_LOCAL_ADDRESS.getKey(), "127.0.0.1"),
+                        stringAttribute(NetworkAttributes.NETWORK_PEER_ADDRESS.getKey(), "192.168.99.101"),
+                        intAttribute(NetworkAttributes.NETWORK_PEER_PORT.getKey(), 9000),
                         stringAttribute("peer.service", "backend"),
                         stringAttribute("clnt/finagle.version", "6.45.0"),
-                        stringAttribute("url.path", "/api"))
+                        stringAttribute(UrlAttributes.URL_PATH.getKey(), "/api"),
+                        stringAttribute("method", "GET"),
+                        stringAttribute("status", "200"))
                 )
                 .addAllEvents(Arrays.asList(
                     Event.newBuilder().setTimeUnixNano(
@@ -123,6 +130,55 @@ class SpanTranslatorTest {
     io.opentelemetry.proto.common.v1.InstrumentationScope scope = implementationScope(tracesData);
     assertThat(scope.getName()).isEqualTo("com.example.app");
     assertThat(scope.getVersion()).isEqualTo("3.3.5");
+  }
+
+  @Test
+  void custom_attributesMapping() {
+    MutableSpan braveSpan = clientSpan();
+    Map<String, String> tagToAttributes = new LinkedHashMap<>();
+    tagToAttributes.put("method", HttpAttributes.HTTP_REQUEST_METHOD.getKey());
+    tagToAttributes.put("status", HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey());
+    SpanTranslator translator = SpanTranslator.newBuilder()
+        .errorTag(Tags.ERROR)
+        .resourceAttributes(Collections.emptyMap())
+        .instrumentationScope(BraveScope.instrumentationScope())
+        .tagToAttributes(TagToAttributes.newBuilder().withDefaults().tagToAttributes(tagToAttributes).build())
+        .build();
+    TracesData tracesData = translator.translate(braveSpan);
+    assertThat(firstSpan(tracesData))
+        .isEqualTo(
+            Span.newBuilder()
+                .setTraceId(ByteString.fromHex(braveSpan.traceId()))
+                .setSpanId(ByteString.fromHex(braveSpan.id()))
+                .setParentSpanId(ByteString.fromHex(braveSpan.parentId()))
+                .setName("get")
+                .setKind(SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(
+                    TimeUnit.MILLISECONDS.toNanos(
+                        Instant.ofEpochSecond(1472470996, 199_000_000).toEpochMilli()))
+                .setEndTimeUnixNano(
+                    TimeUnit.MILLISECONDS.toNanos(
+                        Instant.ofEpochSecond(1472470996, 406_000_000).toEpochMilli()))
+                .addAllAttributes(
+                    Arrays.asList(stringAttribute(NetworkAttributes.NETWORK_LOCAL_ADDRESS.getKey(), "127.0.0.1"),
+                        stringAttribute(NetworkAttributes.NETWORK_PEER_ADDRESS.getKey(), "192.168.99.101"),
+                        intAttribute(NetworkAttributes.NETWORK_PEER_PORT.getKey(), 9000),
+                        stringAttribute("peer.service", "backend"),
+                        stringAttribute("clnt/finagle.version", "6.45.0"),
+                        stringAttribute(UrlAttributes.URL_PATH.getKey(), "/api"),
+                        stringAttribute(HttpAttributes.HTTP_REQUEST_METHOD.getKey(), "GET"),
+                        stringAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey(), "200"))
+                )
+                .addAllEvents(Arrays.asList(
+                    Event.newBuilder().setTimeUnixNano(
+                            TimeUnit.MILLISECONDS.toNanos(
+                                Instant.ofEpochSecond(1472470996, 238_000_000).toEpochMilli()))
+                        .setName("foo").build(),
+                    Event.newBuilder().setTimeUnixNano(TimeUnit.MILLISECONDS.toNanos(
+                            Instant.ofEpochSecond(1472470996, 403_000_000).toEpochMilli()))
+                        .setName("bar").build()))
+                .setStatus(Status.newBuilder().setCode(StatusCode.STATUS_CODE_OK).build())
+                .build());
   }
 
   private static io.opentelemetry.proto.common.v1.InstrumentationScope implementationScope(TracesData translated) {

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TagToAttributesTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TagToAttributesTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.otel.brave;
+
+import brave.http.HttpTags;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.semconv.HttpAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.reporter.otel.brave.TagToAttribute.stringAttribute;
+
+class TagToAttributesTest {
+
+  @Test
+  void defaultMappingShouldMapMethodTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.METHOD.key(), "GET");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(HttpAttributes.HTTP_REQUEST_METHOD.getKey(), "GET"));
+  }
+
+  @Test
+  void defaultMappingShouldMapPathTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.PATH.key(), "/entries/123");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(UrlAttributes.URL_PATH.getKey(), "/entries/123"));
+  }
+
+  @Test
+  void defaultMappingShouldMapRouteTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.ROUTE.key(), "/entries/{entryId}");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(HttpAttributes.HTTP_ROUTE.getKey(), "/entries/{entryId}"));
+  }
+
+  @Test
+  void defaultMappingShouldMapUrlTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "https://example.com/entries/123");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(UrlAttributes.URL_FULL.getKey(), "https://example.com/entries/123"),
+            stringAttribute(UrlAttributes.URL_SCHEME.getKey(), "https"),
+            stringAttribute(UrlAttributes.URL_PATH.getKey(), "/entries/123"));
+  }
+
+  @Test
+  void defaultMappingShouldMapUrlTagWithQueryAndFragment() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "https://example.com/search?q=OpenTelemetry#SemConv");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(
+            stringAttribute(UrlAttributes.URL_FULL.getKey(), "https://example.com/search?q=OpenTelemetry#SemConv"),
+            stringAttribute(UrlAttributes.URL_SCHEME.getKey(), "https"),
+            stringAttribute(UrlAttributes.URL_PATH.getKey(), "/search"),
+            stringAttribute(UrlAttributes.URL_QUERY.getKey(), "q=OpenTelemetry"),
+            stringAttribute(UrlAttributes.URL_FRAGMENT.getKey(), "SemConv"));
+  }
+
+  @Test
+  void defaultMappingShouldMapUrlTagNotFull() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "/entries/123");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(UrlAttributes.URL_PATH.getKey(), "/entries/123"));
+  }
+
+  @Test
+  void defaultMappingShouldNotMapViolatedUrlTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "https://example.com/entries|123");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(HttpTags.URL.key(), "https://example.com/entries|123"));
+  }
+
+  @Test
+  void defaultMappingShouldNotMapUnexpectedUrlTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "abc");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList()).containsExactlyInAnyOrder(stringAttribute(HttpTags.URL.key(), "abc"));
+  }
+
+  @Test
+  void defaultMappingShouldMapStatusCodeTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.STATUS_CODE.key(), "200");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey(), "200"));
+  }
+
+  @Test
+  void defaultMappingShouldNotMapUnknownTag() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, "status", "200");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList()).containsExactlyInAnyOrder(stringAttribute("status", "200"));
+  }
+
+  @Test
+  void customMappingShouldMap() {
+    TagToAttributes tagToAttributes = TagToAttributes.newBuilder()
+        .withDefaults()
+        .tagToAttribute("status", HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey())
+        .build();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, "status", "200");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey(), "200"));
+  }
+}

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TestObjects.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TestObjects.java
@@ -24,6 +24,8 @@ public class TestObjects {
     braveSpan.annotate(1472470996403000L, "bar");
     braveSpan.tag("clnt/finagle.version", "6.45.0");
     braveSpan.tag("http.path", "/api");
+    braveSpan.tag("method", "GET");
+    braveSpan.tag("status", "200");
     return braveSpan;
   }
 }


### PR DESCRIPTION
This pull request makes it possible to configure the logic for converting Brave tags to OTel attributes.  

The motivation behind this change is that Spring Framework has its own conventions for tags, and I wanted to provide a way to convert these into semantic conventions as much as possible.
Reference: https://docs.spring.io/spring-framework/reference/integration/observability.html#observability.http-server 
Additionally, I wanted to offer a way to disable the automatic conversion performed on the brave-otel side.   

Until now, the conversion between tags and attributes assumed a one-to-one relationship. However, recognizing that there can be cases where this assumption doesn't hold, I introduced support for one-to-many or conditional conversions via `TagToAttribute` interface.  

To enable this functionality, I refactored the `SpanTranslator`.  

With this new capability to add custom conversions, I removed the conversion for Brave's non-standard `http.host` tag. This is because it was unclear whether this tag should be converted to `server.address` or `url.domain` (experimental). I believe it's best to leave this decision to users if such a conversion is necessary.  