### PR TITLE
Support mapping brave info to otel server/client.address/port attributes

### DIFF
--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SemanticConventionsAttributes.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SemanticConventionsAttributes.java
@@ -24,6 +24,12 @@ final class SemanticConventionsAttributes {
   static final String NETWORK_PEER_PORT = "network.peer.port";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/ServerAttributes.java#L27
   static final String SERVER_ADDRESS = "server.address";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/ServerAttributes.java#L38
+  static final String SERVER_PORT = "server.port";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/ClientAttributes.java#L27
+  static final String CLIENT_ADDRESS = "client.address";
+  // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/ClientAttributes.java#L38
+  static final String CLIENT_PORT = "client.port";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/ServiceAttributes.java#L27
   static final String SERVICE_NAME = "service.name";
   // https://github.com/open-telemetry/semantic-conventions-java/blob/v1.29.0/semconv/src/main/java/io/opentelemetry/semconv/UrlAttributes.java#L61

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SpanTranslator.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SpanTranslator.java
@@ -22,7 +22,6 @@ import io.opentelemetry.proto.trace.v1.TracesData;
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
 
 import static zipkin2.reporter.otel.brave.TagToAttribute.maybeAddIntAttribute;
 import static zipkin2.reporter.otel.brave.TagToAttribute.maybeAddStringAttribute;
@@ -158,17 +157,11 @@ final class SpanTranslator {
         .addAttributes(stringAttribute(SemanticConventionsAttributes.TELEMETRY_SDK_NAME, TELEMETRY_SDK_NAME))
         .addAttributes(stringAttribute(SemanticConventionsAttributes.TELEMETRY_SDK_VERSION, TELEMETRY_SDK_VERSION));
     if (span.kind() == Kind.SERVER || span.kind() == Kind.CONSUMER) {
-      resolveAddressAndPort(span, span.localIp(), span.localPort(), (address, port) -> {
-        maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_ADDRESS, address);
-        maybeAddIntAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_PORT, port);
-      });
+      resolveAddressAndPort(span, span.localIp(), span.localPort(), spanBuilder);
       maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.CLIENT_ADDRESS, span.remoteIp());
       maybeAddIntAttribute(spanBuilder, SemanticConventionsAttributes.CLIENT_PORT, span.remotePort());
     } else if (span.kind() == Kind.CLIENT || span.kind() == Kind.PRODUCER) {
-      resolveAddressAndPort(span, span.remoteIp(), span.remotePort(), (address, port) -> {
-        maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_ADDRESS, address);
-        maybeAddIntAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_PORT, port);
-      });
+      resolveAddressAndPort(span, span.remoteIp(), span.remotePort(), spanBuilder);
     }
     maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.PEER_SERVICE, span.remoteServiceName());
     span.forEachTag(tagToAttributes, spanBuilder);
@@ -183,7 +176,7 @@ final class SpanTranslator {
     return spanBuilder;
   }
 
-  void resolveAddressAndPort(MutableSpan span, String fallbackAddress, int fallbackPort, BiConsumer<String, Integer> addressAndPortConsumer) {
+  void resolveAddressAndPort(MutableSpan span, String fallbackAddress, int fallbackPort, Span.Builder spanBuilder) {
     String url = span.tag(HttpTags.URL.key());
     String address = null;
     int port = 0;
@@ -202,7 +195,8 @@ final class SpanTranslator {
       } catch (IllegalArgumentException ignored) {
       }
     }
-    addressAndPortConsumer.accept(address == null ? fallbackAddress : address, port == 0 ? fallbackPort : port);
+    maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_ADDRESS, address == null ? fallbackAddress : address);
+    maybeAddIntAttribute(spanBuilder, SemanticConventionsAttributes.SERVER_PORT, port == 0 ? fallbackPort : port);
   }
 
   private static SpanKind translateKind(Kind kind) {

--- a/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SpanTranslator.java
+++ b/encoder-brave/src/main/java/zipkin2/reporter/otel/brave/SpanTranslator.java
@@ -157,11 +157,11 @@ final class SpanTranslator {
         .addAttributes(stringAttribute(SemanticConventionsAttributes.TELEMETRY_SDK_NAME, TELEMETRY_SDK_NAME))
         .addAttributes(stringAttribute(SemanticConventionsAttributes.TELEMETRY_SDK_VERSION, TELEMETRY_SDK_VERSION));
     if (span.kind() == Kind.SERVER || span.kind() == Kind.CONSUMER) {
-      resolveAddressAndPort(span, span.localIp(), span.localPort(), spanBuilder);
+      setServerAddressAndPort(span, span.localIp(), span.localPort(), spanBuilder);
       maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.CLIENT_ADDRESS, span.remoteIp());
       maybeAddIntAttribute(spanBuilder, SemanticConventionsAttributes.CLIENT_PORT, span.remotePort());
     } else if (span.kind() == Kind.CLIENT || span.kind() == Kind.PRODUCER) {
-      resolveAddressAndPort(span, span.remoteIp(), span.remotePort(), spanBuilder);
+      setServerAddressAndPort(span, span.remoteIp(), span.remotePort(), spanBuilder);
     }
     maybeAddStringAttribute(spanBuilder, SemanticConventionsAttributes.PEER_SERVICE, span.remoteServiceName());
     span.forEachTag(tagToAttributes, spanBuilder);
@@ -176,7 +176,7 @@ final class SpanTranslator {
     return spanBuilder;
   }
 
-  void resolveAddressAndPort(MutableSpan span, String fallbackAddress, int fallbackPort, Span.Builder spanBuilder) {
+  void setServerAddressAndPort(MutableSpan span, String fallbackAddress, int fallbackPort, Span.Builder spanBuilder) {
     String url = span.tag(HttpTags.URL.key());
     String address = null;
     int port = 0;

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/OtelToZipkinSpanTransformerTest.java
@@ -473,8 +473,8 @@ class OtelToZipkinSpanTransformerTest {
                             .setTraceId(SpanTranslator.INVALID_TRACE_ID)
                             .setKind(
                                 toSpanKind(spanKind))
-                            .addAttributes(stringAttribute("network.peer.address", "8.8.8.8"))
-                            .addAttributes(intAttribute("network.peer.port", 42))
+                            .addAttributes(stringAttribute("server.address", "8.8.8.8"))
+                            .addAttributes(intAttribute("server.port", 42))
                             .addAttributes(stringAttribute("peer.service", "remote-test-service"))
                             .setStatus(
                                 Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
@@ -513,8 +513,8 @@ class OtelToZipkinSpanTransformerTest {
                             .setTraceId(SpanTranslator.INVALID_TRACE_ID)
                             .setKind(
                                 toSpanKind(spanKind))
-                            .addAttributes(stringAttribute("network.peer.address", "8.8.8.8"))
-                            .addAttributes(intAttribute("network.peer.port", 42))
+                            .addAttributes(stringAttribute("client.address", "8.8.8.8"))
+                            .addAttributes(intAttribute("client.port", 42))
                             .addAttributes(stringAttribute("peer.service", "remote-test-service"))
                             .setStatus(
                                 Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
@@ -552,8 +552,8 @@ class OtelToZipkinSpanTransformerTest {
                             .setTraceId(SpanTranslator.INVALID_TRACE_ID)
                             .setKind(
                                 toSpanKind(spanKind))
-                            .addAttributes(stringAttribute("network.peer.address", "8.8.8.8"))
-                            .addAttributes(intAttribute("network.peer.port", 42))
+                            .addAttributes(stringAttribute("server.address", "8.8.8.8"))
+                            .addAttributes(intAttribute("server.port", 42))
                             .setStatus(
                                 Status.newBuilder().setCode(StatusCode.STATUS_CODE_OK).build())
                             .build())
@@ -590,7 +590,7 @@ class OtelToZipkinSpanTransformerTest {
                             .setTraceId(SpanTranslator.INVALID_TRACE_ID)
                             .setKind(
                                 toSpanKind(spanKind))
-                            .addAttributes(stringAttribute("network.peer.address", "8.8.8.8"))
+                            .addAttributes(stringAttribute("server.address", "8.8.8.8"))
                             .addAttributes(stringAttribute("peer.service", "remote-test-service"))
                             .setStatus(
                                 Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())

--- a/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TagToAttributesTest.java
+++ b/encoder-brave/src/test/java/zipkin2/reporter/otel/brave/TagToAttributesTest.java
@@ -83,6 +83,18 @@ class TagToAttributesTest {
   }
 
   @Test
+  void defaultMappingShouldMapUrlTagNotFullButWithQueryAndFragment() {
+    TagToAttributes tagToAttributes = TagToAttributes.create();
+    Span.Builder spanBuilder = Span.newBuilder();
+    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "/search?q=OpenTelemetry#SemConv");
+    Span span = spanBuilder.build();
+    assertThat(span.getAttributesList())
+        .containsExactlyInAnyOrder(stringAttribute(UrlAttributes.URL_PATH.getKey(), "/search"),
+            stringAttribute(UrlAttributes.URL_QUERY.getKey(), "q=OpenTelemetry"),
+            stringAttribute(UrlAttributes.URL_FRAGMENT.getKey(), "SemConv"));
+  }
+
+  @Test
   void defaultMappingShouldNotMapViolatedUrlTag() {
     TagToAttributes tagToAttributes = TagToAttributes.create();
     Span.Builder spanBuilder = Span.newBuilder();
@@ -90,15 +102,6 @@ class TagToAttributesTest {
     Span span = spanBuilder.build();
     assertThat(span.getAttributesList())
         .containsExactlyInAnyOrder(stringAttribute(HttpTags.URL.key(), "https://example.com/entries|123"));
-  }
-
-  @Test
-  void defaultMappingShouldNotMapUnexpectedUrlTag() {
-    TagToAttributes tagToAttributes = TagToAttributes.create();
-    Span.Builder spanBuilder = Span.newBuilder();
-    tagToAttributes.accept(spanBuilder, HttpTags.URL.key(), "abc");
-    Span span = spanBuilder.build();
-    assertThat(span.getAttributesList()).containsExactlyInAnyOrder(stringAttribute(HttpTags.URL.key(), "abc"));
   }
 
   @Test


### PR DESCRIPTION
This is a continuation of #27.

Basically, I followed the following document and mapped attributes with a requirement Level of "required" to support them as much as possible.

* HTTP Client https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client
* HTTP Server https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server

On the other hand, I stopped setting `network.peer.*` attributes at this translator level because existing information in Brave alone cannot determine cases such as "the client goes through a proxy" as given in the example at https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-client-server-example. I would like to leave it up to the sender or instrumentation side to explicitly set these attributes as needed.