### PR TITLE
Add OTLP http/json endpoint on the collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The component in a zipkin server that receives trace data is called a
 collector. A collector decodes spans reported by applications and
 persists them to a configured collector component.
 
-| Collector                          | Description                                                                             |
-|------------------------------------|-----------------------------------------------------------------------------------------|
-| [collector-http](./collector-http) | Implements the [OTLP/HTTP protocol](https://opentelemetry.io/docs/specs/otlp/#otlphttp) |
+| Collector                          | Description                                                                                                                    |
+|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| [collector-http](./collector-http) | Implements the [OTLP/HTTP protocol](https://opentelemetry.io/docs/specs/otlp/#otlphttp). Both Protobuf and JSON are supported. |
 
 #### Signal Handling
 

--- a/collector-http/pom.xml
+++ b/collector-http/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>4.28.3</version>
+    </dependency>
+    <dependency>
       <groupId>${zipkin.groupId}</groupId>
       <artifactId>zipkin-tests</artifactId>
       <version>${zipkin.version}</version>

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -66,11 +66,6 @@ final class SpanTranslator {
     return spans;
   }
 
-  // for backward compatibility
-  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
-    return translate(otelSpans, false);
-  }
-
   /**
    * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance.
    *

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -19,6 +19,7 @@ import io.opentelemetry.proto.trace.v1.Status;
 import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -50,7 +51,7 @@ final class SpanTranslator {
     this(DefaultOtelResourceMapper.create());
   }
 
-  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
+  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans, boolean base64Decoded) {
     List<zipkin2.Span> spans = new ArrayList<>();
     List<ResourceSpans> spansList = otelSpans.getResourceSpansList();
     for (ResourceSpans resourceSpans : spansList) {
@@ -58,21 +59,28 @@ final class SpanTranslator {
       for (ScopeSpans scopeSpans : resourceSpans.getScopeSpansList()) {
         InstrumentationScope scope = scopeSpans.getScope();
         for (io.opentelemetry.proto.trace.v1.Span span : scopeSpans.getSpansList()) {
-          spans.add(generateSpan(span, scope, resource));
+          spans.add(generateSpan(span, scope, resource, base64Decoded));
         }
       }
     }
     return spans;
   }
 
+  // for backward compatibility
+  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
+    return translate(otelSpans, false);
+  }
+
   /**
    * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance.
    *
-   * @param spanData an OpenTelemetry spanData instance
-   * @param scope    InstrumentationScope of the span
+   * @param spanData      an OpenTelemetry spanData instance
+   * @param scope         InstrumentationScope of the span
+   * @param base64Decoded Whether traceId and spanId are byte arrays that are Base64 decoded strings
    * @return a new Zipkin Span
    */
-  private zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource) {
+  private zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource,
+      boolean base64Decoded) {
     long startTimestamp = nanoToMills(spanData.getStartTimeUnixNano());
     long endTimestamp = nanoToMills(spanData.getEndTimeUnixNano());
     Map<String, AnyValue> attributesMap = spanData.getAttributesList()
@@ -81,11 +89,20 @@ final class SpanTranslator {
             (a, b) -> b /* The latter wins */));
     zipkin2.Span.Builder spanBuilder = zipkin2.Span.newBuilder();
     byte[] traceIdBytes = spanData.getTraceId().toByteArray();
-    long high = bytesToLong(traceIdBytes, 0);
-    long low = bytesToLong(traceIdBytes, 8);
+    byte[] spanIdBytes = spanData.getSpanId().toByteArray();
+    if (base64Decoded) {
+      // Protobuf JSON parser interprets the hex strings of traceId and spanId as Base64 encoded strings,
+      // and stores the decoded byte arrays.
+      spanBuilder.traceId(Base64.getEncoder().encodeToString(traceIdBytes))
+          .id(Base64.getEncoder().encodeToString(spanIdBytes));
+    } else {
+      long high = bytesToLong(traceIdBytes, 0);
+      long low = bytesToLong(traceIdBytes, 8);
+      spanBuilder
+          .traceId(high, low)
+          .id(bytesToLong(spanIdBytes, 0));
+    }
     spanBuilder
-        .traceId(high, low)
-        .id(bytesToLong(spanData.getSpanId().toByteArray(), 0))
         .kind(toSpanKind(spanData.getKind()))
         .name(spanData.getName())
         .timestamp(nanoToMills(spanData.getStartTimeUnixNano()))

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/LogEventTranslatorTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/LogEventTranslatorTest.java
@@ -23,7 +23,7 @@ class LogEventTranslatorTest {
   void nullSpanShouldBeReturnedWithoutSpanId() {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setSpanId(ByteString.fromHex("7180c278b62e8f6a216a2aea45d08fc9"))
-        .build());
+        .build(), false);
     assertThat(span).isNull();
   }
 
@@ -31,7 +31,7 @@ class LogEventTranslatorTest {
   void nullSpanShouldBeReturnedWithoutTraceId() {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setTraceId(ByteString.fromHex("6b221d5bc9e6496c6b221d5bc9e6496c"))
-        .build());
+        .build(), false);
     assertThat(span).isNull();
   }
 
@@ -40,7 +40,7 @@ class LogEventTranslatorTest {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setSpanId(ByteString.fromHex("7180c278b62e8f6a216a2aea45d08fc9"))
         .setTraceId(ByteString.fromHex("6b221d5bc9e6496c6b221d5bc9e6496c"))
-        .build());
+        .build(), false);
     assertThat(span).isNull();
   }
 
@@ -53,7 +53,7 @@ class LogEventTranslatorTest {
         .setSeverityNumber(SeverityNumber.SEVERITY_NUMBER_INFO)
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build());
+        .build(), false);
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -71,7 +71,7 @@ class LogEventTranslatorTest {
         .setSeverityText("INFO")
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build());
+        .build(), false);
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -89,7 +89,7 @@ class LogEventTranslatorTest {
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
         .setDroppedAttributesCount(3)
-        .build());
+        .build(), false);
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -112,7 +112,7 @@ class LogEventTranslatorTest {
                 .setKey("int")
                 .setValue(AnyValue.newBuilder().setIntValue(2)))))
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build());
+        .build(), false);
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
@@ -41,7 +41,7 @@ class SpanTranslatorTest {
     Span expected = zipkinSpanBuilder(Span.Kind.SERVER)
         .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
         .build();
-    assertThat(spanTranslator.translate(data)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
   }
 
   @Test
@@ -53,7 +53,7 @@ class SpanTranslatorTest {
         .parentId(0)
         .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
         .build();
-    assertThat(spanTranslator.translate(data)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
   }
 
   @Test
@@ -61,7 +61,7 @@ class SpanTranslatorTest {
     ExportTraceServiceRequest data = requestBuilderWithSpanCustomizer(span -> span
         .setTraceId(ByteString.fromHex("00000000000000000000000000000000")))
         .build();
-    assertThatThrownBy(() -> spanTranslator.translate(data))
+    assertThatThrownBy(() -> spanTranslator.translate(data, false))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -70,7 +70,7 @@ class SpanTranslatorTest {
     ExportTraceServiceRequest data = requestBuilderWithSpanCustomizer(span -> span
         .setSpanId(ByteString.fromHex("0000000000000000")))
         .build();
-    assertThatThrownBy(() -> spanTranslator.translate(data))
+    assertThatThrownBy(() -> spanTranslator.translate(data, false))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -86,14 +86,14 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .duration(1)
             .build();
-    assertThat(spanTranslator.translate(data)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
   }
 
   @Test
   void translate_ServerKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_SERVER)).build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.SERVER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -104,7 +104,7 @@ class SpanTranslatorTest {
   void translate_ClientKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_CLIENT)).build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.CLIENT)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -115,7 +115,7 @@ class SpanTranslatorTest {
   void translate_InternalKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_INTERNAL)).build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(
             zipkinSpanBuilder(null)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -126,7 +126,7 @@ class SpanTranslatorTest {
   void translate_ConsumeKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_CONSUMER)).build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.CONSUMER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -137,7 +137,7 @@ class SpanTranslatorTest {
   void translate_ProducerKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_PRODUCER)).build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.PRODUCER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -159,7 +159,7 @@ class SpanTranslatorTest {
             .localEndpoint(expectedLocalEndpoint)
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
-    assertThat(spanTranslator.translate(data)).containsExactly(expectedZipkinSpan);
+    assertThat(spanTranslator.translate(data, false)).containsExactly(expectedZipkinSpan);
   }
 
   @Test
@@ -172,7 +172,7 @@ class SpanTranslatorTest {
             .localEndpoint(null)
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedZipkinSpan);
   }
 
@@ -202,7 +202,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -227,7 +227,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -246,7 +246,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -274,7 +274,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -301,7 +301,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -339,7 +339,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -357,7 +357,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -377,7 +377,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -399,7 +399,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -421,7 +421,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -438,7 +438,7 @@ class SpanTranslatorTest {
             .putTag("rpc.service", "my service name")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -457,7 +457,7 @@ class SpanTranslatorTest {
             .putTag(SpanTranslator.OTEL_DROPPED_ATTRIBUTES_COUNT, "1")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -483,7 +483,7 @@ class SpanTranslatorTest {
             .putTag("hostname", "localhost")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 
@@ -512,7 +512,7 @@ class SpanTranslatorTest {
             .putTag("otel.resources.hostname", "localhost")
             .build();
 
-    assertThat(spanTranslator.translate(data))
+    assertThat(spanTranslator.translate(data, false))
         .containsExactly(expectedSpan);
   }
 }

--- a/collector-http/src/test/resources/otel-config.yaml
+++ b/collector-http/src/test/resources/otel-config.yaml
@@ -1,0 +1,30 @@
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch:
+    send_batch_size: 5 # the same number as the span size in the tests
+    timeout: 30s
+exporters:
+  debug: # { verbosity: detailed }
+  otlphttp:
+    endpoint: ${OTLP_EXPORTER_ENDPOINT}
+    encoding: json
+    tls:
+      insecure: true
+service:
+  extensions: [ health_check ]
+  pipelines:
+    traces:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ debug, otlphttp ]
+    logs:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ debug, otlphttp ]


### PR DESCRIPTION
This PR adds support for json encoding in addition to protobuf for Zipkin's OTLP/HTTP endpoints.