### PR TITLE
Fix OTLP/JSON trace ID handling

### DIFF
--- a/collector-http/src/main/java/zipkin2/collector/otel/http/LogEventTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/LogEventTranslator.java
@@ -13,7 +13,6 @@ import io.opentelemetry.proto.logs.v1.ResourceLogs;
 import io.opentelemetry.proto.logs.v1.ScopeLogs;
 import io.opentelemetry.proto.logs.v1.SeverityNumber;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import zipkin2.Span;
@@ -57,13 +56,13 @@ final class LogEventTranslator {
         : builder.resourceMapper;
   }
 
-  List<Span> translate(ExportLogsServiceRequest logs, boolean base64Decoded) {
+  List<Span> translate(ExportLogsServiceRequest logs) {
     ArrayList<Span> spans = new ArrayList<>();
     List<ResourceLogs> resourceLogsList = logs.getResourceLogsList();
     for (ResourceLogs resourceLogs : resourceLogsList) {
       for (ScopeLogs scopeLogs : resourceLogs.getScopeLogsList()) {
         for (LogRecord logRecord : scopeLogs.getLogRecordsList()) {
-          Span span = generateSpan(logRecord, base64Decoded);
+          Span span = generateSpan(logRecord);
           if (span != null) {
             spans.add(span);
           }
@@ -74,7 +73,7 @@ final class LogEventTranslator {
   }
 
   @Nullable
-  Span generateSpan(LogRecord logRecord, boolean base64Decoded) {
+  Span generateSpan(LogRecord logRecord) {
     // the log record must have both trace id and span id
     if (logRecord.getTraceId().isEmpty() || logRecord.getSpanId().isEmpty()) {
       return null;
@@ -112,17 +111,10 @@ final class LogEventTranslator {
     Span.Builder spanBuilder = Span.newBuilder();
     byte[] traceIdBytes = logRecord.getTraceId().toByteArray();
     byte[] spanIdBytes = logRecord.getSpanId().toByteArray();
-    if (base64Decoded) {
-      // Protobuf JSON parser interprets the hex strings of traceId and spanId as Base64 encoded strings,
-      // and stores the decoded byte arrays.
-      spanBuilder.traceId(Base64.getEncoder().encodeToString(traceIdBytes))
-          .id(Base64.getEncoder().encodeToString(spanIdBytes));
-    } else {
-      long high = bytesToLong(traceIdBytes, 0);
-      long low = bytesToLong(traceIdBytes, 8);
-      spanBuilder.traceId(high, low)
-          .id(bytesToLong(spanIdBytes, 0));
-    }
+    long high = bytesToLong(traceIdBytes, 0);
+    long low = bytesToLong(traceIdBytes, 8);
+    spanBuilder.traceId(high, low)
+        .id(bytesToLong(spanIdBytes, 0));
     return spanBuilder
         .addAnnotation(timestamp, annotationValue)
         .build();

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/OpenTelemetryHttpCollector.java
@@ -160,21 +160,20 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
               return null;
             }
             ExportTraceServiceRequest request;
-            boolean base64Decoded = false;
             if (contentType.isProtobuf()) {
               request = ExportTraceServiceRequest.parseFrom(
                   UnsafeByteOperations.unsafeWrap(content.byteBuf().nioBuffer()).newCodedInput());
             } else if (contentType.isJson()) {
               ExportTraceServiceRequest.Builder builder = ExportTraceServiceRequest.newBuilder();
               collector.jsonParser.merge(content.toReaderUtf8(), builder);
+              ProtoUtils.fixJsonIds(builder);
               request = builder.build();
-              base64Decoded = true;
             } else {
               throw new IllegalArgumentException("Unsupported Content-Type: " + contentType);
             }
             collector.metrics.incrementMessages();
             try {
-              List<Span> spans = spanTranslator.translate(request, base64Decoded);
+              List<Span> spans = spanTranslator.translate(request);
               collector.collector.accept(spans, result);
             } catch (RuntimeException e) {
               // If the span is invalid, an exception such as IllegalArgumentException will be thrown.
@@ -232,21 +231,20 @@ public final class OpenTelemetryHttpCollector extends CollectorComponent
               return null;
             }
             ExportLogsServiceRequest request;
-            boolean base64Decoded = false;
             if (contentType.isProtobuf()) {
               request = ExportLogsServiceRequest.parseFrom(
                   UnsafeByteOperations.unsafeWrap(content.byteBuf().nioBuffer()).newCodedInput());
             } else if (contentType.isJson()) {
               ExportLogsServiceRequest.Builder builder = ExportLogsServiceRequest.newBuilder();
               collector.jsonParser.merge(content.toReaderUtf8(), builder);
+              ProtoUtils.fixJsonIds(builder);
               request = builder.build();
-              base64Decoded = true;
             } else {
               throw new IllegalArgumentException("Unsupported Content-Type: " + contentType);
             }
             collector.metrics.incrementMessages();
             try {
-              List<Span> spans = logEventTranslator.translate(request, base64Decoded);
+              List<Span> spans = logEventTranslator.translate(request);
               collector.collector.accept(spans, result);
             } catch (RuntimeException e) {
               // TODO count dropped spans

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/ProtoUtils.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/ProtoUtils.java
@@ -4,14 +4,72 @@
  */
 package zipkin2.collector.otel.http;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.TextFormat;
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.logs.v1.LogRecord;
+import io.opentelemetry.proto.logs.v1.ResourceLogs;
+import io.opentelemetry.proto.logs.v1.ScopeLogs;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 
 import static java.util.stream.Collectors.joining;
 
 final class ProtoUtils {
+
+  /**
+   * Fixes trace, span and parent IDs that were mis-decoded by {@code JsonFormat.parser()}.
+   *
+   * <p>OTLP/JSON encodes trace and span IDs as hex strings, but protobuf's JSON parser treats
+   * {@code bytes} fields as base64, producing wrong bytes. This recovers the original hex and
+   * re-decodes it correctly.
+   *
+   * <p>The Go collector handles this natively via hex decode:
+   * https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/bytesid.go
+   *
+   * @see <a href="https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding">OTLP JSON encoding</a>
+   */
+  static void fixJsonIds(ExportTraceServiceRequest.Builder builder) {
+    for (ResourceSpans.Builder rs : builder.getResourceSpansBuilderList()) {
+      for (ScopeSpans.Builder ss : rs.getScopeSpansBuilderList()) {
+        for (io.opentelemetry.proto.trace.v1.Span.Builder span : ss.getSpansBuilderList()) {
+          span.setTraceId(hexToBytes(span.getTraceId()));
+          span.setSpanId(hexToBytes(span.getSpanId()));
+          span.setParentSpanId(hexToBytes(span.getParentSpanId()));
+          for (io.opentelemetry.proto.trace.v1.Span.Link.Builder link : span.getLinksBuilderList()) {
+            link.setTraceId(hexToBytes(link.getTraceId()));
+            link.setSpanId(hexToBytes(link.getSpanId()));
+          }
+        }
+      }
+    }
+  }
+
+  /** Same as above, for log records which also carry trace and span IDs. */
+  static void fixJsonIds(ExportLogsServiceRequest.Builder builder) {
+    for (ResourceLogs.Builder rl : builder.getResourceLogsBuilderList()) {
+      for (ScopeLogs.Builder sl : rl.getScopeLogsBuilderList()) {
+        for (LogRecord.Builder log : sl.getLogRecordsBuilderList()) {
+          log.setTraceId(hexToBytes(log.getTraceId()));
+          log.setSpanId(hexToBytes(log.getSpanId()));
+        }
+      }
+    }
+  }
+
+  /** Re-encodes mis-decoded bytes back to the original hex, then decodes as proper hex. */
+  static ByteString hexToBytes(ByteString hexReadAsBase64) {
+    if (hexReadAsBase64.isEmpty()) return hexReadAsBase64;
+    String hex = Base64.getEncoder().encodeToString(hexReadAsBase64.toByteArray())
+        .toLowerCase(Locale.ROOT);
+    return ByteString.fromHex(hex);
+  }
   static String kvListToJson(List<KeyValue> attributes) {
     return attributes.stream()
         .map(entry -> "\"" + entry.getKey() + "\":" + valueToJson(entry.getValue()))

--- a/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
+++ b/collector-http/src/main/java/zipkin2/collector/otel/http/SpanTranslator.java
@@ -19,7 +19,6 @@ import io.opentelemetry.proto.trace.v1.Status;
 import io.opentelemetry.proto.trace.v1.Status.StatusCode;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -51,7 +50,7 @@ final class SpanTranslator {
     this(DefaultOtelResourceMapper.create());
   }
 
-  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans, boolean base64Decoded) {
+  List<zipkin2.Span> translate(ExportTraceServiceRequest otelSpans) {
     List<zipkin2.Span> spans = new ArrayList<>();
     List<ResourceSpans> spansList = otelSpans.getResourceSpansList();
     for (ResourceSpans resourceSpans : spansList) {
@@ -59,23 +58,14 @@ final class SpanTranslator {
       for (ScopeSpans scopeSpans : resourceSpans.getScopeSpansList()) {
         InstrumentationScope scope = scopeSpans.getScope();
         for (io.opentelemetry.proto.trace.v1.Span span : scopeSpans.getSpansList()) {
-          spans.add(generateSpan(span, scope, resource, base64Decoded));
+          spans.add(generateSpan(span, scope, resource));
         }
       }
     }
     return spans;
   }
 
-  /**
-   * Creates an instance of a Zipkin Span from an OpenTelemetry SpanData instance.
-   *
-   * @param spanData      an OpenTelemetry spanData instance
-   * @param scope         InstrumentationScope of the span
-   * @param base64Decoded Whether traceId and spanId are byte arrays that are Base64 decoded strings
-   * @return a new Zipkin Span
-   */
-  private zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource,
-      boolean base64Decoded) {
+  private zipkin2.Span generateSpan(Span spanData, InstrumentationScope scope, Resource resource) {
     long startTimestamp = nanoToMills(spanData.getStartTimeUnixNano());
     long endTimestamp = nanoToMills(spanData.getEndTimeUnixNano());
     Map<String, AnyValue> attributesMap = spanData.getAttributesList()
@@ -85,18 +75,11 @@ final class SpanTranslator {
     zipkin2.Span.Builder spanBuilder = zipkin2.Span.newBuilder();
     byte[] traceIdBytes = spanData.getTraceId().toByteArray();
     byte[] spanIdBytes = spanData.getSpanId().toByteArray();
-    if (base64Decoded) {
-      // Protobuf JSON parser interprets the hex strings of traceId and spanId as Base64 encoded strings,
-      // and stores the decoded byte arrays.
-      spanBuilder.traceId(Base64.getEncoder().encodeToString(traceIdBytes))
-          .id(Base64.getEncoder().encodeToString(spanIdBytes));
-    } else {
-      long high = bytesToLong(traceIdBytes, 0);
-      long low = bytesToLong(traceIdBytes, 8);
-      spanBuilder
-          .traceId(high, low)
-          .id(bytesToLong(spanIdBytes, 0));
-    }
+    long high = bytesToLong(traceIdBytes, 0);
+    long low = bytesToLong(traceIdBytes, 8);
+    spanBuilder
+        .traceId(high, low)
+        .id(bytesToLong(spanIdBytes, 0));
     spanBuilder
         .kind(toSpanKind(spanData.getKind()))
         .name(spanData.getName())

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/ITOpenTelemetryHttpCollector.java
@@ -486,6 +486,48 @@ class ITOpenTelemetryHttpCollector {
     assertThat(metrics.bytes()).isEqualTo(tracesData.getSerializedSize());
   }
 
+  /** Span data from https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/trace.json */
+  @Test
+  void minimalSpanJson() throws Exception {
+    String json = """
+        {
+          "resourceSpans": [{
+            "resource": {
+              "attributes": [{"key": "service.name", "value": {"stringValue": "my.service"}}]
+            },
+            "scopeSpans": [{
+              "scope": {"name": "my.library", "version": "1.0.0"},
+              "spans": [{
+                "traceId": "5B8EFFF798038103D269B633813FC60C",
+                "spanId": "EEE19B7EC3C1B174",
+                "parentSpanId": "EEE19B7EC3C1B173",
+                "name": "I'm a server span",
+                "startTimeUnixNano": "1544712660000000000",
+                "endTimeUnixNano": "1544712661000000000",
+                "kind": 2
+              }]
+            }]
+          }]
+        }""";
+
+    URL url = URI.create("http://localhost:" + port + "/v1/traces").toURL();
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("POST");
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/json");
+    try (OutputStream os = connection.getOutputStream()) {
+      os.write(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+      os.flush();
+    }
+    int responseCode = connection.getResponseCode();
+    connection.disconnect();
+    assertThat(responseCode).isEqualTo(HttpURLConnection.HTTP_ACCEPTED);
+    Awaitility.waitAtMost(Duration.ofMillis(200))
+        .untilAsserted(() -> assertThat(store.acceptedSpanCount()).isEqualTo(1));
+    assertThat(metrics.spans()).isEqualTo(1);
+    assertThat(metrics.messages()).isEqualTo(1);
+  }
+
   @Test
   void invalidSpanId() throws Exception {
     TracesData tracesData = TracesData.newBuilder()

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/LogEventTranslatorTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/LogEventTranslatorTest.java
@@ -23,7 +23,7 @@ class LogEventTranslatorTest {
   void nullSpanShouldBeReturnedWithoutSpanId() {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setSpanId(ByteString.fromHex("7180c278b62e8f6a216a2aea45d08fc9"))
-        .build(), false);
+        .build());
     assertThat(span).isNull();
   }
 
@@ -31,7 +31,7 @@ class LogEventTranslatorTest {
   void nullSpanShouldBeReturnedWithoutTraceId() {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setTraceId(ByteString.fromHex("6b221d5bc9e6496c6b221d5bc9e6496c"))
-        .build(), false);
+        .build());
     assertThat(span).isNull();
   }
 
@@ -40,7 +40,7 @@ class LogEventTranslatorTest {
     Span span = logEventTranslator.generateSpan(LogRecord.newBuilder()
         .setSpanId(ByteString.fromHex("7180c278b62e8f6a216a2aea45d08fc9"))
         .setTraceId(ByteString.fromHex("6b221d5bc9e6496c6b221d5bc9e6496c"))
-        .build(), false);
+        .build());
     assertThat(span).isNull();
   }
 
@@ -53,7 +53,7 @@ class LogEventTranslatorTest {
         .setSeverityNumber(SeverityNumber.SEVERITY_NUMBER_INFO)
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build(), false);
+        .build());
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -71,7 +71,7 @@ class LogEventTranslatorTest {
         .setSeverityText("INFO")
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build(), false);
+        .build());
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -89,7 +89,7 @@ class LogEventTranslatorTest {
         .setBody(AnyValue.newBuilder().setStringValue("Hello World!").build())
         .addAttributes(stringAttribute("event.name", "demo.event"))
         .setDroppedAttributesCount(3)
-        .build(), false);
+        .build());
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")
@@ -112,7 +112,7 @@ class LogEventTranslatorTest {
                 .setKey("int")
                 .setValue(AnyValue.newBuilder().setIntValue(2)))))
         .addAttributes(stringAttribute("event.name", "demo.event"))
-        .build(), false);
+        .build());
     assertThat(span).isEqualTo(Span.newBuilder()
         .id("7180c278b62e8f6a")
         .traceId("6b221d5bc9e6496c6b221d5bc9e6496c")

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/ProtoUtilsTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/ProtoUtilsTest.java
@@ -5,6 +5,8 @@
 package zipkin2.collector.otel.http;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.util.JsonFormat;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -17,6 +19,35 @@ import static zipkin2.collector.otel.http.ProtoUtils.kvListToJson;
 import static zipkin2.collector.otel.http.ProtoUtils.valueToJson;
 
 class ProtoUtilsTest {
+
+  /** Verifies fix for hex IDs mis-decoded as base64 by {@link JsonFormat#parser()}. */
+  @Test
+  void fixJsonIds_recoversHexTraceAndSpanIds() throws Exception {
+    String json = """
+        {
+          "resourceSpans": [{
+            "scopeSpans": [{
+              "spans": [{
+                "traceId": "5B8EFFF798038103D269B633813FC60C",
+                "spanId": "EEE19B7EC3C1B174",
+                "parentSpanId": "EEE19B7EC3C1B173"
+              }]
+            }]
+          }]
+        }""";
+    ExportTraceServiceRequest.Builder builder = ExportTraceServiceRequest.newBuilder();
+    JsonFormat.parser().merge(json, builder);
+    ProtoUtils.fixJsonIds(builder);
+    ExportTraceServiceRequest request = builder.build();
+
+    ByteString traceId = request.getResourceSpans(0).getScopeSpans(0).getSpans(0).getTraceId();
+    ByteString spanId = request.getResourceSpans(0).getScopeSpans(0).getSpans(0).getSpanId();
+    ByteString parentSpanId = request.getResourceSpans(0).getScopeSpans(0).getSpans(0).getParentSpanId();
+
+    assertThat(traceId).isEqualTo(ByteString.fromHex("5b8efff798038103d269b633813fc60c"));
+    assertThat(spanId).isEqualTo(ByteString.fromHex("eee19b7ec3c1b174"));
+    assertThat(parentSpanId).isEqualTo(ByteString.fromHex("eee19b7ec3c1b173"));
+  }
 
   @Test
   void testValueToJson() {

--- a/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
+++ b/collector-http/src/test/java/zipkin2/collector/otel/http/SpanTranslatorTest.java
@@ -41,7 +41,7 @@ class SpanTranslatorTest {
     Span expected = zipkinSpanBuilder(Span.Kind.SERVER)
         .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
         .build();
-    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data)).containsExactly(expected);
   }
 
   @Test
@@ -53,7 +53,38 @@ class SpanTranslatorTest {
         .parentId(0)
         .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
         .build();
-    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data)).containsExactly(expected);
+  }
+
+  /** Span data from https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/trace.json */
+  @Test
+  void translate_jsonParsedRequest() throws Exception {
+    String json = """
+        {
+          "resourceSpans": [{
+            "resource": {
+              "attributes": [{"key": "service.name", "value": {"stringValue": "my.service"}}]
+            },
+            "scopeSpans": [{
+              "scope": {"name": "my.library", "version": "1.0.0"},
+              "spans": [{
+                "traceId": "5B8EFFF798038103D269B633813FC60C",
+                "spanId": "EEE19B7EC3C1B174",
+                "parentSpanId": "EEE19B7EC3C1B173",
+                "name": "I'm a server span",
+                "startTimeUnixNano": "1544712660000000000",
+                "endTimeUnixNano": "1544712661000000000",
+                "kind": 2
+              }]
+            }]
+          }]
+        }""";
+    ExportTraceServiceRequest.Builder builder = ExportTraceServiceRequest.newBuilder();
+    com.google.protobuf.util.JsonFormat.parser().merge(json, builder);
+    ProtoUtils.fixJsonIds(builder);
+    assertThat(spanTranslator.translate(builder.build())).hasSize(1);
+    assertThat(spanTranslator.translate(builder.build()).get(0).traceId())
+        .isEqualTo("5b8efff798038103d269b633813fc60c");
   }
 
   @Test
@@ -61,7 +92,7 @@ class SpanTranslatorTest {
     ExportTraceServiceRequest data = requestBuilderWithSpanCustomizer(span -> span
         .setTraceId(ByteString.fromHex("00000000000000000000000000000000")))
         .build();
-    assertThatThrownBy(() -> spanTranslator.translate(data, false))
+    assertThatThrownBy(() -> spanTranslator.translate(data))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -70,7 +101,7 @@ class SpanTranslatorTest {
     ExportTraceServiceRequest data = requestBuilderWithSpanCustomizer(span -> span
         .setSpanId(ByteString.fromHex("0000000000000000")))
         .build();
-    assertThatThrownBy(() -> spanTranslator.translate(data, false))
+    assertThatThrownBy(() -> spanTranslator.translate(data))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -86,14 +117,14 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .duration(1)
             .build();
-    assertThat(spanTranslator.translate(data, false)).containsExactly(expected);
+    assertThat(spanTranslator.translate(data)).containsExactly(expected);
   }
 
   @Test
   void translate_ServerKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_SERVER)).build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.SERVER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -104,7 +135,7 @@ class SpanTranslatorTest {
   void translate_ClientKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_CLIENT)).build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.CLIENT)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -115,7 +146,7 @@ class SpanTranslatorTest {
   void translate_InternalKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_INTERNAL)).build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(
             zipkinSpanBuilder(null)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -126,7 +157,7 @@ class SpanTranslatorTest {
   void translate_ConsumeKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_CONSUMER)).build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.CONSUMER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -137,7 +168,7 @@ class SpanTranslatorTest {
   void translate_ProducerKind() {
     ExportTraceServiceRequest data = ZipkinTestUtil.requestBuilderWithSpanCustomizer(span -> span
         .setKind(SpanKind.SPAN_KIND_PRODUCER)).build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(
             zipkinSpanBuilder(Span.Kind.PRODUCER)
                 .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
@@ -159,7 +190,7 @@ class SpanTranslatorTest {
             .localEndpoint(expectedLocalEndpoint)
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
-    assertThat(spanTranslator.translate(data, false)).containsExactly(expectedZipkinSpan);
+    assertThat(spanTranslator.translate(data)).containsExactly(expectedZipkinSpan);
   }
 
   @Test
@@ -172,7 +203,7 @@ class SpanTranslatorTest {
             .localEndpoint(null)
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedZipkinSpan);
   }
 
@@ -202,7 +233,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -227,7 +258,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -246,7 +277,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -274,7 +305,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -301,7 +332,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -339,7 +370,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -357,7 +388,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "OK")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -377,7 +408,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -399,7 +430,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -421,7 +452,7 @@ class SpanTranslatorTest {
             .putTag(OtelAttributes.OTEL_STATUS_CODE.getKey(), "ERROR")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -438,7 +469,7 @@ class SpanTranslatorTest {
             .putTag("rpc.service", "my service name")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -457,7 +488,7 @@ class SpanTranslatorTest {
             .putTag(SpanTranslator.OTEL_DROPPED_ATTRIBUTES_COUNT, "1")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -483,7 +514,7 @@ class SpanTranslatorTest {
             .putTag("hostname", "localhost")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 
@@ -512,7 +543,7 @@ class SpanTranslatorTest {
             .putTag("otel.resources.hostname", "localhost")
             .build();
 
-    assertThat(spanTranslator.translate(data, false))
+    assertThat(spanTranslator.translate(data))
         .containsExactly(expectedSpan);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
     <main.java.version>1.8</main.java.version>
     <main.signature.artifact>java18</main.signature.artifact>
 
+    <!-- Tests use the floor Java version (used in release) -->
+    <maven.compiler.testSource>17</maven.compiler.testSource>
+    <maven.compiler.testTarget>17</maven.compiler.testTarget>
+    <maven.compiler.testRelease>17</maven.compiler.testRelease>
+
     <!-- groupId overrinds allow testing feature branches with jitpack -->
     <!-- matching armeria/grpc/zipkin -->
     <zipkin.groupId>io.zipkin.zipkin2</zipkin.groupId>


### PR DESCRIPTION
## Summary

`JsonFormat.parser()` decodes `bytes` fields as base64 per the protobuf spec, but [OTLP/JSON uses hex](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) for trace and span IDs. This produced wrong bytes causing `IllegalArgumentException: should be lower-hex encoded`.

The fix adds `ProtoUtils.fixJsonIds` which corrects mis-decoded IDs after parsing, using the same approach as
[opentelemetry-java tests](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/common/src/test/java/io/opentelemetry/exporter/internal/otlp/traces/TraceRequestMarshalerTest.java#L535-L580). The Go collector handles this natively via [hex decode](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/bytesid.go).

This also removes the `base64Decoded` flag from `SpanTranslator` and `LogEventTranslator`, and sets `maven.compiler.testRelease=17` to allow text blocks in tests.

## Testing

Test data from https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/trace.json

Docker smoke test with OTLP protobuf:
```
$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./mvnw clean install -DskipTests -Prelease -Dgpg.skip
$ RELEASE_FROM_MAVEN_BUILD=true build-bin/docker/docker_build openzipkin-contrib/zipkin-otel:test
$ docker run -d --name sut -p 9411:9411 openzipkin-contrib/zipkin-otel:test
$ curl -s localhost:9411/health | grep OpenTelemetryHttpCollector
      "OpenTelemetryHttpCollector{}" : {
$ curl -s -o /dev/null -w "%{http_code}" -X POST localhost:9411/api/v2/spans     -H 'Content-Type: application/json'     -d '[{"traceId":"aaaa","id":"bbbb","name":"test","timestamp":1,"duration":1,
         "localEndpoint":{"serviceName":"smoketest"}}]'
202
$ curl -s localhost:9411/api/v2/trace/aaaa
[{"traceId":"000000000000000000000000000000aa"...}]
$ docker rm -f sut
```